### PR TITLE
fix(data, core): Collei talent fix; remove unused (& incorrect)  `skillReaction` event

### DIFF
--- a/docs/development/data/events.md
+++ b/docs/development/data/events.md
@@ -115,7 +115,6 @@
 | `damagedOrHealed`        | `onDamageOrHeal`         | 我方/所附着角色受到伤害或治疗后             |
 | `defeated`               | `onDamageOrHeal`         | 我方/所附着角色倒下时                       |
 | `reaction`               | `onReaction`             | 我方/所附着**角色上发生**元素反应后         |
-| `skillReaction`          | `onReaction`             | 我方/所附着**角色引发**元素反应后           |
 | `enter`                  | `onEnter`                | 实体**自身**入场时                          |
 | `enterRelative`          | `onEnter`                | **我方**实体入场时                          |
 | `dispose`                | `onDispose`              | **我方**实体弃置时                          |

--- a/packages/core/src/builder/skill.ts
+++ b/packages/core/src/builder/skill.ts
@@ -546,11 +546,6 @@ export const detailedEventDictionary = {
   dealReaction: defineDescriptor("onReaction", (e, r) => {
     return checkRelative(e.onTimeState, e.caller.id, r);
   }),
-  skillReaction: defineDescriptor("onReaction", (e, r) => {
-    return (
-      checkRelative(e.onTimeState, e.caller.id, r) && e.viaCharacterSkill()
-    );
-  }),
   enter: defineDescriptor("onEnter", (e, r) => {
     return e.entity.id === r.callerId;
   }),

--- a/packages/data/src/characters/dendro/collei.ts
+++ b/packages/data/src/characters/dendro/collei.ts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { character, skill, summon, combatStatus, card, DamageType, SkillHandle } from "@gi-tcg/core/builder";
+import { character, skill, summon, combatStatus, card, DamageType, SkillHandle, $ } from "@gi-tcg/core/builder";
 
 /**
  * @id 117011
@@ -36,9 +36,19 @@ export const CuileinAnbar = summon(117011)
  */
 export const Sprout = combatStatus(117012)
   .duration(1)
-  .on("skillReaction", (c, e) => e.relatedTo(DamageType.Dendro))
+  .on("useSkill", (c) => c.hasPhaseReaction("my", (e) => e.relatedTo(DamageType.Dendro)))
   .usagePerRound(1)
   .damage(DamageType.Dendro, 1)
+  .done();
+
+/**
+ * @id 117013
+ * @name 新叶(已创建)
+ * @description
+ * 本回合中无法再生成新的新叶。
+ */
+export const SproutCreated = combatStatus(117013)
+  .oneDuration()
   .done();
 
 /**
@@ -64,8 +74,12 @@ export const FloralBrush: SkillHandle = skill(17012)
   .type("elemental")
   .costDendro(3)
   .damage(DamageType.Dendro, 3)
-  .if((c) => c.self.hasEquipment(FloralSidewinder))
-  .combatStatus(Sprout)
+  .do((c) => {
+    if (c.self.hasEquipment(FloralSidewinder) && !c.query($.my.combatStatus.def(SproutCreated))) {
+      c.combatStatus(Sprout);
+      c.combatStatus(SproutCreated);
+    }
+  })
   .done();
 
 /**

--- a/packages/test/__tests__/collei.test.tsx
+++ b/packages/test/__tests__/collei.test.tsx
@@ -13,12 +13,12 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { ref, setup, State, Character, Support, $, Card } from "#test";
+import { ref, setup, State, Character, Card } from "#test";
 import { Collei, FloralSidewinder } from "@gi-tcg/data/internal/characters/dendro/collei";
 import { Aura } from "@gi-tcg/typings";
 import { test } from "bun:test";
 
-test("collei: talent status won't applied to defeated characters", async () => {
+test("collei: talent status won't target on defeated characters", async () => {
   const chosenNext = ref();
   const collei = ref();
   const c = setup(

--- a/packages/test/__tests__/collei.test.tsx
+++ b/packages/test/__tests__/collei.test.tsx
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 Piovium Labs
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { ref, setup, State, Character, Support, $, Card } from "#test";
+import { Collei, FloralSidewinder } from "@gi-tcg/data/internal/characters/dendro/collei";
+import { Aura } from "@gi-tcg/typings";
+import { test } from "bun:test";
+
+test("collei: talent status won't applied to defeated characters", async () => {
+  const chosenNext = ref();
+  const collei = ref();
+  const c = setup(
+    <State>
+      <Character opp health={1} aura={Aura.Hydro} />
+      <Character opp ref={chosenNext} health={10} />
+      <Character my def={Collei} ref={collei} />
+      <Card my def={FloralSidewinder} />
+    </State>
+  );
+  await c.me.card(FloralSidewinder, collei);
+  await c.opp.chooseActive(chosenNext);
+  c.expect(chosenNext).toHaveVariable({ health: 9, aura: Aura.Dendro });
+});


### PR DESCRIPTION
<!--
Thank you for your contribution! To help us review your pull request more efficiently, please fill out the following sections:

- Clearly describe what you changed and why.
- Explain how you verified that your changes are correct.
-->

## What Changed

Correct Collei talent's implementation from an incorrect configured `skillReaction` to `useSkill` + `hasPhaseReaction` detection.

The `skillReaction` is unused any more and removed from `core`.

<!-- Describe the changes you made. What functionality, code, or files did you update? Why was this change necessary? -->

## How to Prove It Works

Add a UT to prove the talent handling is triggered at `onUseSkill`.

<!-- Explain how you tested your changes. Did you run unit tests, integration tests, or manual verifications? Please provide steps or evidence that demonstrate your change is correct. -->
