### PR TITLE
refactor(core): Single Event List

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+/// <reference types="./env.d.ts" />
+
 /** Toggle this when editing beta version. */
 export const IS_BETA = false;
 

--- a/packages/core/src/base/skill.ts
+++ b/packages/core/src/base/skill.ts
@@ -69,7 +69,7 @@ import type { PlainCharacterState } from "../builder/context/utils";
 import type { AppliableDamageType } from "../builder/type";
 import type { MoveEntityM, RemoveEntityM } from "./mutation";
 import type { LunarReaction } from "@gi-tcg/typings";
-import type { DamageOption } from "../mutator";
+import type { DamageOption, ReadonlyEventList } from "../mutator";
 
 export interface SkillDefinitionBase<Arg> {
   readonly type: "skill";
@@ -86,8 +86,12 @@ export type StateMutationAndExposedMutation = {
   stateMutations: Mutation[];
 };
 
-export type SkillResult = {
-  readonly emittedEvents: readonly EventAndRequest[];
+export interface CoreSkillResult {
+  readonly emittedEvents: ReadonlyEventList;
+  readonly causeDefeated: boolean;
+}
+
+export interface SkillResult extends CoreSkillResult {
   readonly innerNotify: StateMutationAndExposedMutation;
   readonly mainDamage: DamageInfo | null;
 };
@@ -99,6 +103,7 @@ export const EMPTY_SKILL_RESULT: SkillResult = {
     stateMutations: [],
   },
   mainDamage: null,
+  causeDefeated: false,
 };
 
 export type SkillDescriptionReturn = readonly [GameState, SkillResult];
@@ -640,8 +645,8 @@ export class ModifyAction4EventArg<
 > extends ModifyActionEventArgBase<InfoT> {
   setFastAction(): void {
     if (this._fast) {
-      console?.warn("Potential error: fast action already set");
-      console?.trace();
+      console?.warn?.("Potential error: fast action already set");
+      console?.trace?.();
     }
     this._log += `${stringifyState(this.caller)} set fast action.\n`;
     this._fast = true;
@@ -949,8 +954,8 @@ export class ModifyDamage0EventArg extends ModifyDamageEventArgBase {
       super.damageInfo.type
     }] to [damage:${type}].\n`;
     if (this._newDamageType !== null) {
-      console?.warn("Potential error: damage type already changed");
-      console?.trace();
+      console?.warn?.("Potential error: damage type already changed");
+      console?.trace?.();
     }
     this._newDamageType = type;
   }
@@ -1393,7 +1398,8 @@ export type InlineEventNames =
   | "modifyHeal0"
   | "modifyHeal1"
   | "modifyChangeVariable"
-  | "modifyReaction";
+  | "modifyReaction"
+  | "modifyZeroHealth";
 
 export type EventArgOf<E extends EventNames> = InstanceType<EventMap[E]>;
 

--- a/packages/core/src/builder/context/skill.ts
+++ b/packages/core/src/builder/context/skill.ts
@@ -288,7 +288,6 @@ export class SkillContext<Meta extends ContextMetaBase> {
     for (const event of this.eventAndRequests) {
       const [name, arg] = event;
       if (name === "onDamageOrHeal" && arg.isDamageTypeDamage()) {
-        let critical = false;
         if (arg.damageInfo.causeDefeated) {
           // Wrap original EventArg to ZeroHealthEventArg
           const zeroHealthEventArg = new ZeroHealthEventArg(
@@ -348,11 +347,10 @@ export class SkillContext<Meta extends ContextMetaBase> {
                 failedPlayers.add(defeatedCh.who);
               }
             }
-            critical = true;
+            criticalDamageEvents.push(event);
+          } else {
+            safeDamageEvents.push(["onDamageOrHeal", zeroHealthEventArg]);
           }
-        }
-        if (critical) {
-          criticalDamageEvents.push(event);
         } else {
           safeDamageEvents.push(event);
         }

--- a/packages/core/src/builder/context/skill.ts
+++ b/packages/core/src/builder/context/skill.ts
@@ -28,7 +28,6 @@ import {
   type VariableValueChangeInfo,
   type DamageInfo,
   DamageOrHealEventArg,
-  type DisposeOrTuneMethod,
   type EventAndRequest,
   type EventAndRequestConstructorArgs,
   type EventAndRequestNames,
@@ -41,6 +40,8 @@ import {
   BeforeVariableEventArg,
   ZeroHealthEventArg,
   ReactionEventArg,
+  EMPTY_SKILL_RESULT,
+  type CoreSkillResult,
 } from "../../base/skill";
 import {
   type CharacterState as CharacterStateO,
@@ -50,7 +51,6 @@ import {
   type GameState,
   type PhaseType,
   type PlayerState,
-  StateSymbol,
   stringifyState,
 } from "../../base/state";
 import {
@@ -77,7 +77,6 @@ import type {
   StatusHandle,
   SummonHandle,
   EquipmentHandle,
-  SupportHandle,
   AttachmentHandle,
 } from "../type";
 import type { GuessedTypeOfQuery } from "../../query-legacy/types";
@@ -86,11 +85,13 @@ import { flip } from "@gi-tcg/utils";
 import { GiTcgDataError } from "../../error";
 import { DetailLogType } from "../../log";
 import {
+  EventList,
   GiTcgPreviewAbortedError,
   type InsertPileStrategy,
   type InternalHealOption,
   type InternalNotifyOption,
   type MutatorConfig,
+  type ReadonlyEventList,
   StateMutator,
 } from "../../mutator";
 import { type Draft, produce } from "immer";
@@ -185,8 +186,8 @@ type ShortcutReturn<
   : T;
 
 type MutatorResultCanEmit =
-  | readonly EventAndRequest[]
-  | { readonly events: readonly EventAndRequest[] };
+  | ReadonlyEventList
+  | { readonly events: ReadonlyEventList };
 
 type MutatorMethodCanEmitImpl<K extends keyof StateMutator> =
   StateMutator[K] extends (...args: any[]) => MutatorResultCanEmit ? K : never;
@@ -197,9 +198,9 @@ type MutatorMethodCanEmit = {
 
 type CallAndEmitResult<K extends MutatorMethodCanEmit> = ReturnType<
   StateMutator[K]
-> extends { readonly events: readonly EventAndRequest[] }
+> extends { readonly events: ReadonlyEventList }
   ? Omit<ReturnType<StateMutator[K]>, "events">
-  : ReturnType<StateMutator[K]> extends readonly EventAndRequest[]
+  : ReturnType<StateMutator[K]> extends ReadonlyEventList
     ? void
     : never;
 
@@ -220,7 +221,7 @@ export class SkillContext<Meta extends ContextMetaBase> {
     ReturnType<typeof Proxy.revocable>
   >();
 
-  private readonly eventAndRequests: EventAndRequest[] = [];
+  private readonly eventAndRequests = new EventList();
   private mainDamage: DamageInfo | null = null;
 
   private enableShortcut(): ShortcutReturn<Meta>;
@@ -267,56 +268,142 @@ export class SkillContext<Meta extends ContextMetaBase> {
 
   /**
    * 对技能返回的事件列表预处理。
-   * - 将重复目标的“伤害事件”合并。
-   * - 对未导致爆牌的 HCI 事件，若目标牌已弃置，则删除之
    */
-  private preprocessEventList() {
-    const result: EventAndRequest[] = [];
-    const damageEventIndexInResultBasedOnTarget = new Map<number, number>();
+  private preprocessEventList(): CoreSkillResult {
+    const otherEvents: EventAndRequest[] = [];
+    const hciEvents: EventAndRequest[] = [];
+    const safeDamageEvents: EventAndRequest[] = [];
+    const criticalDamageEvents: EventAndRequest[] = [];
+
+    const failedPlayers = new Set<0 | 1>();
+
+    // 将 originalEvents 分类
+    // - 对于 damage，先判断：
+    //   - 若可能击倒但应用 modifyZeroHealth 后免于被击倒，则内联执行后
+    //     将事件继续添加到 originalEvents 中（通常仅有治疗事件）
+    //   - 若确实击倒切无法被免于被击倒，则归类为 criticalDamageEvents，
+    //     否则归类为 safeDamageEvents
+    // - 对于 HCI，删去目标已被舍弃的事件，其余归入 hciEvents
+    // - 其余类型归类为 otherEvents
     for (const event of this.eventAndRequests) {
       const [name, arg] = event;
       if (name === "onDamageOrHeal" && arg.isDamageTypeDamage()) {
-        const previousIndex = damageEventIndexInResultBasedOnTarget.get(
-          arg.target.id,
-        );
-        if (typeof previousIndex !== "undefined") {
-          // combine current event with previous event
-          const previousArg = result[
-            previousIndex
-          ][1] as DamageOrHealEventArg<DamageInfo>;
-          const combinedDamageInfo: DamageInfo = {
-            ...previousArg.damageInfo,
-            value: previousArg.damageInfo.value + arg.damageInfo.value,
-            causeDefeated:
-              previousArg.damageInfo.causeDefeated ||
-              arg.damageInfo.causeDefeated,
-            fromReaction:
-              previousArg.damageInfo.fromReaction ||
-              arg.damageInfo.fromReaction,
-          };
-          result[previousIndex][1] = new DamageOrHealEventArg(
-            previousArg.onTimeState,
-            combinedDamageInfo,
-            previousArg.option,
+        let critical = false;
+        if (arg.damageInfo.causeDefeated) {
+          // Wrap original EventArg to ZeroHealthEventArg
+          const zeroHealthEventArg = new ZeroHealthEventArg(
+            arg.onTimeState,
+            arg.damageInfo,
+            arg.option,
           );
+          this.callAndEmit(
+            "handleInlineEvent",
+            this.skillInfo,
+            "modifyZeroHealth",
+            zeroHealthEventArg,
+          );
+          if (!zeroHealthEventArg._immuneInfo) {
+            const defeatedCh = this.get(arg.target);
+            if (defeatedCh.variables.alive) {
+              this.mutator.log(
+                DetailLogType.Primitive,
+                `${stringifyState(
+                  defeatedCh,
+                )} is defeated (and no immune available)`,
+              );
+              this.mutate({
+                type: "modifyEntityVar",
+                state: defeatedCh.latest(),
+                varName: "alive",
+                value: 0,
+                direction: "decrease",
+              });
+              const energyVarName =
+                defeatedCh.definition.specialEnergy?.variableName ?? "energy";
+              this.mutate({
+                type: "modifyEntityVar",
+                state: defeatedCh.latest(),
+                varName: energyVarName,
+                value: 0,
+                direction: "decrease",
+              });
+              this.mutate({
+                type: "modifyEntityVar",
+                state: defeatedCh.latest(),
+                varName: "aura",
+                value: Aura.None,
+                direction: null,
+              });
+              this.mutate({
+                type: "setPlayerFlag",
+                who: defeatedCh.who,
+                flagName: "hasDefeated",
+                value: true,
+              });
+              const player = this.state.players[defeatedCh.who];
+              const aliveCharacters = player.characters.filter(
+                (ch) => ch.variables.alive,
+              );
+              if (aliveCharacters.length === 0) {
+                failedPlayers.add(defeatedCh.who);
+              }
+            }
+            critical = true;
+          }
+        }
+        if (critical) {
+          criticalDamageEvents.push(event);
         } else {
-          damageEventIndexInResultBasedOnTarget.set(
-            arg.target.id,
-            result.length,
-          );
-          result.push(event);
+          safeDamageEvents.push(event);
         }
       } else if (name === "onHandCardInserted") {
         const shouldDrop =
           !arg.overflowed && this.get(arg.card).area.type === "removedEntities";
         if (!shouldDrop) {
-          result.push(event);
+          hciEvents.push(event);
         }
       } else {
-        result.push(event);
+        otherEvents.push(event);
       }
     }
-    return result;
+
+    if (failedPlayers.size === 2) {
+      this.mutator.log(
+        DetailLogType.Other,
+        `Both player has no alive characters, set winner to null`,
+      );
+      this.mutate({
+        type: "changePhase",
+        newPhase: "gameEnd",
+      });
+      this.mutator.notify();
+      return EMPTY_SKILL_RESULT;
+    } else if (failedPlayers.size === 1) {
+      const who = [...failedPlayers.values()][0];
+      this.mutator.log(
+        DetailLogType.Other,
+        `player ${who} has no alive characters, set winner to ${flip(who)}`,
+      );
+      this.mutate({
+        type: "changePhase",
+        newPhase: "gameEnd",
+      });
+      this.mutate({
+        type: "setWinner",
+        winner: flip(who),
+      });
+      this.mutator.notify();
+      return EMPTY_SKILL_RESULT;
+    }
+
+    const emittedEvents = [
+      ...otherEvents,
+      ...hciEvents,
+      ...safeDamageEvents,
+      ...criticalDamageEvents,
+    ];
+    const causeDefeated = criticalDamageEvents.length > 0;
+    return { emittedEvents, causeDefeated };
   }
 
   /**
@@ -325,8 +412,9 @@ export class SkillContext<Meta extends ContextMetaBase> {
    */
   _terminate(): SkillDescriptionReturn {
     this.mutator.notify();
+    const { emittedEvents, causeDefeated } = this.preprocessEventList();
+    Object.freeze(emittedEvents);
     Object.freeze(this);
-    const emittedEvents = this.preprocessEventList();
     const resultState = this.rawState;
     for (const [, { revoke }] of this._reactiveProxies) {
       revoke();
@@ -337,6 +425,7 @@ export class SkillContext<Meta extends ContextMetaBase> {
         emittedEvents,
         innerNotify: this._savedNotify,
         mainDamage: this.mainDamage,
+        causeDefeated,
       },
     ];
   }
@@ -646,6 +735,7 @@ export class SkillContext<Meta extends ContextMetaBase> {
     );
     this.eventAndRequests.push([event, arg] as EventAndRequest);
   }
+
   // 等效调用 this.mutator.<method>, 并将返回的 events 添加
   callAndEmit<K extends MutatorMethodCanEmit>(
     method: K,
@@ -1935,7 +2025,7 @@ export class SkillContext<Meta extends ContextMetaBase> {
           },
         );
         if (!nightsoulStatus) {
-          console?.warn(
+          console?.warn?.(
             `Failed to create nightsouls blessing for ${stringifyState(
               target,
             )}`,

--- a/packages/core/src/builder/entity.ts
+++ b/packages/core/src/builder/entity.ts
@@ -490,10 +490,10 @@ export class EntityBuilder<
       name !== "usage" &&
       typeof opt?.autoDispose === "boolean"
     ) {
-      console?.warn(
+      console?.warn?.(
         `No need to specify \`autoDispose\` of a non-per-round non-defaulted-name usage, since it cannot be auto-disposed by \`.consumeUsage\` primitive.`,
       );
-      console?.trace();
+      console?.trace?.();
     }
     const autoDispose = name === "usage" && opt?.autoDispose !== false;
     this.variable(name, count, opt);

--- a/packages/core/src/game.ts
+++ b/packages/core/src/game.ts
@@ -99,6 +99,7 @@ import {
   type InternalNotifyOption,
   type InternalPauseOption,
   type MutatorConfig,
+  type ReadonlyEventList,
   StateMutator,
 } from "./mutator";
 import { type ActionInfoWithModification, ActionPreviewer } from "./preview";
@@ -1057,7 +1058,7 @@ export class Game {
           }
         }
       } else {
-        console?.warn(`Card ${card.definition.id} has no play skill defined.`);
+        console?.warn?.(`Card ${card.definition.id} has no play skill defined.`);
       }
 
       result.push({
@@ -1182,7 +1183,7 @@ export class Game {
   private async handleEvent(...args: EventAndRequest) {
     await SkillExecutor.handleEvent(this.mutator, ...args);
   }
-  private async handleEvents(events: EventAndRequest[]) {
+  private async handleEvents(events: ReadonlyEventList) {
     await SkillExecutor.handleEvents(this.mutator, events);
   }
 }

--- a/packages/core/src/mutator.ts
+++ b/packages/core/src/mutator.ts
@@ -144,7 +144,7 @@ export interface InsertEntityResult {
   /** 若成功入场，给出新建的实体状态 */
   readonly newState: EntityState | null;
   /** 若成功入场，则引发的 onEnter 事件 */
-  readonly events: readonly EventAndRequest[];
+  readonly events: ReadonlyEventList;
 }
 
 export interface SwitchActiveOption {
@@ -172,7 +172,7 @@ export interface InternalHealOption {
 
 export interface DamageResult {
   readonly damageInfo: DamageInfo;
-  readonly events: readonly EventAndRequest[];
+  readonly events: ReadonlyEventList;
 }
 
 export type InsertHandPayload =
@@ -194,7 +194,7 @@ export interface InsertHandCardOption {
 
 export interface CreateHandCardResult {
   readonly state: EntityState;
-  readonly events: EventAndRequest[];
+  readonly events: ReadonlyEventList;
 }
 
 export type InsertPileStrategy =
@@ -204,6 +204,65 @@ export type InsertPileStrategy =
   | "spaceAround"
   | `topRange${number}`
   | `topIndex${number}`;
+
+export class EventList extends Array<EventAndRequest> {
+  private damageEventIndexInResultBasedOnTarget = new Map<number, number>();
+
+  /**
+   * 将引发的事件 `[event, arg]` 添加到事件列表中。
+   * Note: 如果是伤害事件，则会基于伤害目标和先前的伤害事件合并。
+   * @returns
+   */
+  override push(...items: EventAndRequest[]) {
+    for (const item of items) {
+      const [event, arg] = item;
+      if (event === "onDamageOrHeal" && arg.isDamageTypeDamage()) {
+        const previousIndex = this.damageEventIndexInResultBasedOnTarget.get(
+          arg.target.id,
+        );
+        if (typeof previousIndex !== "undefined") {
+          // combine current event with previous event
+          const previousArg = this[
+            previousIndex
+          ][1] as DamageOrHealEventArg<DamageInfo>;
+          const combinedDamageInfo: DamageInfo = {
+            ...previousArg.damageInfo,
+            value: previousArg.damageInfo.value + arg.damageInfo.value,
+            causeDefeated:
+              previousArg.damageInfo.causeDefeated ||
+              arg.damageInfo.causeDefeated,
+            fromReaction:
+              previousArg.damageInfo.fromReaction ||
+              arg.damageInfo.fromReaction,
+          };
+          this[previousIndex][1] = new DamageOrHealEventArg(
+            previousArg.onTimeState,
+            combinedDamageInfo,
+            previousArg.option,
+          );
+          continue;
+        } else {
+          this.damageEventIndexInResultBasedOnTarget.set(
+            arg.target.id,
+            this.length,
+          );
+        }
+      }
+      super.push(item);
+    }
+    return this.length;
+  }
+}
+
+export interface ReadonlyEventList extends ReadonlyArray<EventAndRequest> {}
+
+declare global {
+  interface Console {
+    warn?(...data: any[]): void;
+    trace?(): void;
+  }
+  var console: Console | undefined;
+}
 
 /**
  * 管理一个状态和状态的修改；同时也进行日志管理。
@@ -242,9 +301,9 @@ export class StateMutator {
     notifyOpt?: Omit<NotifyOption, "mutations">,
   ) {
     if (this._mutationsToBeNotified.length > 0) {
-      console?.warn("Resetting state with pending mutations not notified");
-      console?.warn(this._mutationsToBeNotified);
-      console?.trace();
+      console?.warn?.("Resetting state with pending mutations not notified");
+      console?.warn?.(this._mutationsToBeNotified);
+      console?.trace?.();
       // debugger;
     }
     this._state = newState;
@@ -344,7 +403,7 @@ export class StateMutator {
     skillDescription: SkillDescription<Arg>,
     skill: SkillInfo,
     arg: Arg,
-  ): readonly EventAndRequest[] {
+  ): ReadonlyEventList {
     this.notify();
     const [newState, { innerNotify, emittedEvents }] = skillDescription(
       this.state,
@@ -358,12 +417,12 @@ export class StateMutator {
     parentSkill: SkillInfo,
     event: E,
     arg: EventArgOf<E>,
-  ): EventAndRequest[] {
+  ): ReadonlyEventList {
     using l = this.subLog(
       DetailLogType.Event,
       `Handling inline event ${event} (${arg.toString()}):`,
     );
-    const events: EventAndRequest[] = [];
+    const events = new EventList();
     const infos = allSkills(this.state, event).map<SkillInfo>(
       ({ caller, skill }) => ({
         caller,
@@ -397,11 +456,11 @@ export class StateMutator {
     target: CharacterState,
     type: NontrivialDamageType,
     opt: ApplyOption,
-  ): EventAndRequest[] {
+  ): ReadonlyEventList {
     if (!target.variables.alive) {
       return [];
     }
-    const events: EventAndRequest[] = [];
+    const events = new EventList();
     const aura = target.variables.aura;
     const { newAura, reaction } = getReaction({
       type,
@@ -496,9 +555,9 @@ export class StateMutator {
     value: number,
     targetState: CharacterState,
     opt: InternalHealOption,
-  ): EventAndRequest[] {
+  ): ReadonlyEventList {
     const damageType = DamageType.Heal;
-    const events: EventAndRequest[] = [];
+    const events = new EventList();
     if (!targetState.variables.alive) {
       if (opt.kind === "revive") {
         this.log(
@@ -608,7 +667,7 @@ export class StateMutator {
         damageInfo.type
       }] damage to ${stringifyState(target)}`,
     );
-    const events: EventAndRequest[] = [];
+    const events = new EventList();
     if (damageInfo.type !== DamageType.Piercing) {
       const modifier = new GenericModifyDamageEventArg(
         this.state,
@@ -692,7 +751,7 @@ export class StateMutator {
   insertHandCard(
     payload: InsertHandPayload,
     opt: InsertHandCardOption = {},
-  ): EventAndRequest[] {
+  ): ReadonlyEventList {
     const who = payload.target.who;
     const reason =
       payload.type === "createEntity" ? ("create" as const) : payload.reason;
@@ -728,8 +787,8 @@ export class StateMutator {
     ];
   }
 
-  drawCardsPlain(who: 0 | 1, count: number): EventAndRequest[] {
-    const events: EventAndRequest[] = [];
+  drawCardsPlain(who: 0 | 1, count: number): ReadonlyEventList {
+    const events = new EventList();
     for (let i = 0; i < count; i++) {
       const card = this.state.players[who].pile[0];
       if (!card) {
@@ -795,7 +854,7 @@ export class StateMutator {
     payloads: InsertPilePayload[],
     strategy: InsertPileStrategy,
     who: 0 | 1,
-  ): EventAndRequest[] {
+  ): ReadonlyEventList {
     const target: EntityArea = { who, type: "pile", cardId: 0 };
     const player = this.state.players[who];
     const pileCount = player.pile.length;
@@ -903,7 +962,7 @@ export class StateMutator {
       );
     }
     const { definition } = stateOrDef;
-    const events: EventAndRequest[] = [];
+    const events = new EventList();
 
     using l = this.subLog(
       DetailLogType.Primitive,
@@ -1001,7 +1060,7 @@ export class StateMutator {
             from: moveFrom,
             oldState: attachment,
             reason: "other", // TODO maybe better reason?
-          })
+          });
         }
         this.mutate({
           type: "moveEntity",
@@ -1039,7 +1098,11 @@ export class StateMutator {
     }
     return { oldState, newState, events };
   }
-  createAttachment(host: EntityState, definition: AttachmentDefinition, opt: CreateEntityOptions) {
+  createAttachment(
+    host: EntityState,
+    definition: AttachmentDefinition,
+    opt: CreateEntityOptions,
+  ) {
     using l = this.subLog(
       DetailLogType.Primitive,
       `Create attachment [attachment:${definition.id}] on ${stringifyState(
@@ -1060,7 +1123,7 @@ export class StateMutator {
       opt,
     });
     let newStateId: number;
-    const events: EventAndRequest[] = [];
+    const events = new EventList();
     if (oldState) {
       this.log(
         DetailLogType.Other,
@@ -1107,7 +1170,7 @@ export class StateMutator {
     who: 0 | 1,
     target: CharacterState,
     opt: SwitchActiveOption = {},
-  ): EventAndRequest[] {
+  ): ReadonlyEventList {
     let from: CharacterState | null;
     if (this.state.players[who].activeCharacterId === 0) {
       from = null;
@@ -1233,7 +1296,7 @@ export class StateMutator {
     }
   }
 
-  async switchHands(who: 0 | 1): Promise<EventAndRequest[]> {
+  async switchHands(who: 0 | 1): Promise<ReadonlyEventList> {
     if (!this.config.howToSwitchHands) {
       throw new GiTcgIoNotProvideError();
     }
@@ -1251,7 +1314,7 @@ export class StateMutator {
     });
     const swapInCardIds = swapInCards.map((c) => c.definition.id);
 
-    const events: EventAndRequest[] = [];
+    const events = new EventList();
 
     for (const card of swapInCards) {
       const randomValue = this.stepRandom();
@@ -1307,7 +1370,7 @@ export class StateMutator {
     who: 0 | 1,
     via: SkillInfo,
     info: SelectCardInfo,
-  ): Promise<EventAndRequest[]> {
+  ): Promise<ReadonlyEventList> {
     if (!this.config.howToSelectCard) {
       throw new GiTcgIoNotProvideError();
     }

--- a/packages/core/src/query-legacy/semantic.ts
+++ b/packages/core/src/query-legacy/semantic.ts
@@ -401,10 +401,10 @@ const tagSpecifierDict: QueryLangActionDict<string[]> = {
     };
     const result = query.doQuery(queryCtx);
     if (result.length !== 1) {
-      console?.warn(
+      console?.warn?.(
         `Indirect tag specifier (${query.sourceString}) is expected to be unique, got ${result.length} instead`,
       );
-      console?.trace();
+      console?.trace?.();
     }
     const tags = result.flatMap((st) => st.definition.tags as string[]);
 

--- a/packages/core/src/query/runtime.ts
+++ b/packages/core/src/query/runtime.ts
@@ -663,10 +663,10 @@ class QueryRunner {
           ),
         ];
         if (baseEntries.length !== 1) {
-          console?.warn(
+          console?.warn?.(
             `Expected exactly one candidate for tagOf query, got ${baseEntries.length}`,
           );
-          console?.trace();
+          console?.trace?.();
         }
         const baseTags = baseEntries.flatMap(
           (entry) => (entry.state.definition.tags as CharacterTag[]) ?? [],

--- a/packages/core/src/skill_executor.ts
+++ b/packages/core/src/skill_executor.ts
@@ -14,35 +14,30 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import {
-  type DamageInfo,
-  DamageOrHealEventArg,
+  type CoreSkillResult,
   defineSkillInfo,
   DisposeEventArg,
   type Event,
   type EventAndRequest,
   EventArg,
   type InitiativeSkillEventArg,
-  RequestArg,
   SelectCardEventArg,
   type SelectCardInfo,
   type SkillEnvironment,
   type SkillInfo,
-  type SwitchActiveInfo,
   type TriggeredSkillDefinition,
   UseSkillEventArg,
-  ZeroHealthEventArg,
 } from "./base/skill";
 import {
   type AnyState,
   type CharacterState,
-  StateSymbol,
+  type GameState,
   stringifyState,
 } from "./base/state";
-import { Aura, PbSkillType, type ExposedMutation } from "@gi-tcg/typings";
+import { PbSkillType, type ExposedMutation } from "@gi-tcg/typings";
 import {
   allSkills,
   type CallerAndTriggeredSkill,
-  checkImmune,
   getActiveCharacterIndex,
   getEntityArea,
   getEntityById,
@@ -55,7 +50,7 @@ import {
 } from "./utils";
 import { flip } from "@gi-tcg/utils";
 import { DetailLogType } from "./log";
-import { StateMutator } from "./mutator";
+import { EventList, StateMutator, type ReadonlyEventList } from "./mutator";
 import type { Mutation } from "./base/mutation";
 
 export type GeneralSkillArg = EventArg | InitiativeSkillEventArg;
@@ -87,9 +82,9 @@ export class SkillExecutor {
   private executeSkill(
     skillInfo: SkillInfo,
     arg: GeneralSkillArg,
-  ): readonly EventAndRequest[] {
+  ): CoreSkillResult {
     if (this.state.phase === "gameEnd") {
-      return [];
+      return { emittedEvents: [], causeDefeated: false };
     }
     using l = this.mutator.subLog(
       DetailLogType.Skill,
@@ -118,7 +113,8 @@ export class SkillExecutor {
 
     const oldState = this.state;
     this.mutator.notify();
-    const [newState, { innerNotify, emittedEvents }] = (0, skillDef.action)(
+    const [newState, { innerNotify, emittedEvents, causeDefeated }] = (0,
+    skillDef.action)(
       this.state,
       {
         ...skillInfo,
@@ -182,7 +178,7 @@ export class SkillExecutor {
     innerNotify.exposedMutations.unshift(...prependMutations);
     this.mutator.resetState(newState, innerNotify);
 
-    return emittedEvents;
+    return { emittedEvents, causeDefeated };
   }
 
   async finalizeSkill(
@@ -192,141 +188,11 @@ export class SkillExecutor {
     if (this.state.phase === "gameEnd") {
       return;
     }
-    let emittedEvents = [...this.executeSkill(skillInfo, arg)];
-    await this.mutator.notifyAndPause();
+    const { emittedEvents, causeDefeated } = this.executeSkill(skillInfo, arg);
 
-    const otherEvents: EventAndRequest[] = [];
-    const hciEvents: EventAndRequest[] = [];
-    const safeDamageEvents: EventAndRequest[] = [];
-    const criticalDamageEvents: EventAndRequest[] = [];
-
-    do {
-      const damageEventArgs: DamageOrHealEventArg<DamageInfo>[] = [];
-      const zeroHealthEventArgs: ZeroHealthEventArg[] = [];
-
-      const failedPlayers = new Set<0 | 1>();
-
-      // 将 emittedEvents 分成 nonDamage 和 damage 两类，
-      // 同时收集 zeroHealth 以处理击倒和免于被击倒
-      for (const event of emittedEvents) {
-        const [name, arg] = event;
-        if (name === "onDamageOrHeal" && arg.isDamageTypeDamage()) {
-          if (arg.damageInfo.causeDefeated) {
-            // Wrap original EventArg to ZeroHealthEventArg
-            const zeroHealthEventArg = new ZeroHealthEventArg(
-              arg.onTimeState,
-              arg.damageInfo,
-              arg.option,
-            );
-            if (checkImmune(this.state, zeroHealthEventArg)) {
-              zeroHealthEventArgs.push(zeroHealthEventArg);
-            } else {
-              const { id } = arg.target;
-              const ch = getEntityById(this.state, id) as CharacterState;
-              const { who } = getEntityArea(this.state, id);
-              if (ch.variables.alive) {
-                this.mutator.log(
-                  DetailLogType.Primitive,
-                  `${stringifyState(ch)} is defeated (and no immune available)`,
-                );
-                this.mutate({
-                  type: "modifyEntityVar",
-                  state: ch,
-                  varName: "alive",
-                  value: 0,
-                  direction: "decrease",
-                });
-                const energyVarName =
-                  ch.definition.specialEnergy?.variableName ?? "energy";
-                this.mutate({
-                  type: "modifyEntityVar",
-                  state: ch,
-                  varName: energyVarName,
-                  value: 0,
-                  direction: "decrease",
-                });
-                this.mutate({
-                  type: "modifyEntityVar",
-                  state: ch,
-                  varName: "aura",
-                  value: Aura.None,
-                  direction: null,
-                });
-                this.mutate({
-                  type: "setPlayerFlag",
-                  who,
-                  flagName: "hasDefeated",
-                  value: true,
-                });
-                const player = this.state.players[who];
-                const aliveCharacters = player.characters.filter(
-                  (ch) => ch.variables.alive,
-                );
-                if (aliveCharacters.length === 0) {
-                  failedPlayers.add(who);
-                }
-              }
-            }
-            damageEventArgs.push(zeroHealthEventArg);
-          } else {
-            damageEventArgs.push(arg);
-          }
-        } else if (name === "onHandCardInserted") {
-          hciEvents.push(event);
-        } else {
-          otherEvents.push(event);
-        }
-      }
-
-      if (failedPlayers.size === 2) {
-        this.mutator.log(
-          DetailLogType.Other,
-          `Both player has no alive characters, set winner to null`,
-        );
-        this.mutate({
-          type: "changePhase",
-          newPhase: "gameEnd",
-        });
-        await this.mutator.notifyAndPause();
-        return;
-      } else if (failedPlayers.size === 1) {
-        const who = [...failedPlayers.values()][0];
-        this.mutator.log(
-          DetailLogType.Other,
-          `player ${who} has no alive characters, set winner to ${flip(who)}`,
-        );
-        this.mutate({
-          type: "changePhase",
-          newPhase: "gameEnd",
-        });
-        this.mutate({
-          type: "setWinner",
-          winner: flip(who),
-        });
-        await this.mutator.notifyAndPause();
-        return;
-      }
-
-      for (const event of damageEventArgs) {
-        if (event.damageInfo.causeDefeated) {
-          criticalDamageEvents.push(["onDamageOrHeal", event]);
-        } else {
-          safeDamageEvents.push(["onDamageOrHeal", event]);
-        }
-      }
-
-      if (criticalDamageEvents.length > 0) {
-        await this.mutator.notifyAndPause();
-      }
-
-      // 继续收集在执行免于被击倒的 onDamageOrHeal 响应时产生的事件
-      emittedEvents = [];
-      for (const arg of zeroHealthEventArgs) {
-        emittedEvents.push(
-          ...this.handleEventShallow(["modifyZeroHealth", arg]),
-        );
-      }
-    } while (emittedEvents.length > 0);
+    if ((this.state as GameState).phase === "gameEnd") {
+      return;
+    }
 
     if (
       skillInfo.caller.definition.type === "character" &&
@@ -365,31 +231,24 @@ export class SkillExecutor {
       }
     }
 
-    await this.handleEvent(...otherEvents);
-    await this.handleEvent(...hciEvents);
-    await this.handleEvent(...safeDamageEvents);
-    await this.handleEvent(...criticalDamageEvents);
+    await this.handleEvent(...emittedEvents);
 
     // 接下来处理出战角色倒下后的切人
-    // 仅当本次技能的使用造成倒下时才会处理
-    if (criticalDamageEvents.length === 0) {
+    // 仅当**本次**技能的使用造成倒下时才会处理
+    if (!causeDefeated) {
       return;
     }
+
     const savedSwitchingFlags = this.state.players.map(
       (p) => p.defeatedSwitching,
     );
-    const switchPromises: [
-      null | Promise<SwitchActiveInfo>,
-      null | Promise<SwitchActiveInfo>,
-    ] = [null, null];
-    for (const who of [0, 1] as const) {
-      const player = this.state.players[who];
+    const switchPromises = this.state.players.map(async (player, who) => {
       const [activeCh] = shiftLeft(
         player.characters,
         getActiveCharacterIndex(player),
       );
       if (activeCh.variables.alive) {
-        continue;
+        return null;
       }
       this.mutator.log(
         DetailLogType.Other,
@@ -401,36 +260,34 @@ export class SkillExecutor {
         flagName: "defeatedSwitching",
         value: true,
       });
-      switchPromises[who] = this.mutator.chooseActive(who).then((to) => ({
+      const to = await this.mutator.chooseActive(who);
+      const switchInfo = {
         type: "switchActive",
         who,
         from: activeCh,
         to,
         fromReaction: false,
         fast: null,
-      }));
-    }
+      };
+      return switchInfo;
+    });
     const switchInfos = await Promise.all(switchPromises);
     this.mutator.postChooseActive(
       ...switchInfos.map((info) => info?.to ?? null),
     );
     const currentTurn = this.state.currentTurn;
-    const switchEvents: EventAndRequest[][] = [[], []];
-    for (const info of switchInfos) {
-      if (info) {
-        using l = this.mutator.subLog(
-          DetailLogType.Primitive,
-          `Player ${info.who} switch active from ${
-            info.from ? stringifyState(info.from) : "(null)"
-          } to ${stringifyState(info.to)}`,
-        );
-        switchEvents[info.who].push(
-          ...this.mutator.switchActive(info.who, info.to),
-        );
-      }
-    }
     for (const who of [currentTurn, flip(currentTurn)]) {
-      await this.handleEvent(...switchEvents[who]);
+      const info = switchInfos[who];
+      if (!info) {
+        continue;
+      }
+      using l = this.mutator.subLog(
+        DetailLogType.Primitive,
+        `Player ${info.who} switch active from ${
+          info.from ? stringifyState(info.from) : "(null)"
+        } to ${stringifyState(info.to)}`,
+      );
+      await this.handleEvent(...this.mutator.switchActive(info.who, info.to));
     }
     for (const who of [0, 1] as const) {
       this.mutator.mutate({
@@ -465,37 +322,6 @@ export class SkillExecutor {
     return callerAndSkills;
   }
 
-  /**
-   * 执行监听 `event` 事件的技能。此过程并不结算这些技能：技能中引发的级联事件将作为结果返回。
-   * @param event
-   * @returns
-   */
-  private handleEventShallow(...events: EventAndRequest[]): EventAndRequest[] {
-    const result: EventAndRequest[] = [];
-    for (const event of events) {
-      const [name, arg] = event;
-      if (arg instanceof RequestArg) {
-        result.push(event);
-        continue;
-      }
-      using guard = this.createHandleEventNotifies(name);
-      const callerAndSkills = this.broadcastEvent(event as Event);
-      for (const { caller, skill } of callerAndSkills) {
-        const skillInfo = defineSkillInfo({
-          caller,
-          definition: skill,
-        });
-        arg._currentSkillInfo = skillInfo;
-        if (!(0, skill.filter)(this.state, skillInfo, arg)) {
-          continue;
-        }
-        const emittedEvents = this.executeSkill(skillInfo, arg);
-        result.push(...emittedEvents);
-      }
-    }
-    return result;
-  }
-
   private createHandleEventNotifies(name: string) {
     this.mutator.notify({
       mutations: [
@@ -525,7 +351,7 @@ export class SkillExecutor {
    * 处理事件 `events`。监听它们的技能将会被递归结算。
    * @param events
    */
-  async handleEvent(...events: EventAndRequest[]) {
+  async handleEvent(...events: ReadonlyEventList) {
     for (const event of events) {
       const [name, arg] = event;
       using guard = this.createHandleEventNotifies(name);
@@ -745,7 +571,7 @@ export class SkillExecutor {
   static async handleEvent(mutator: StateMutator, ...event: EventAndRequest) {
     return SkillExecutor.handleEvents(mutator, [event]);
   }
-  static async handleEvents(mutator: StateMutator, events: EventAndRequest[]) {
+  static async handleEvents(mutator: StateMutator, events: ReadonlyEventList) {
     const executor = new SkillExecutor(mutator, { environment: "normal" });
     await executor.handleEvent(...events);
     return executor.state;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -425,33 +425,6 @@ export function allEntitiesAtArea(
 }
 
 /**
- * 将 `e` 的一份拷贝传入所有响应 `modifyZeroHealth` 的技能，
- * 检查是否存在可使该 `e` 免于被击倒的可能。
- * @param state
- * @param e
- * @returns
- */
-export function checkImmune(state: GameState, e: ZeroHealthEventArg) {
-  const clonedE = new ZeroHealthEventArg(state, e.damageInfo, e.option);
-  for (const { caller, skill } of allSkills(state, "modifyZeroHealth")) {
-    const skillInfo = defineSkillInfo({
-      caller,
-      definition: skill,
-    });
-    clonedE._currentSkillInfo = skillInfo;
-    const filterResult = (0, skill.filter)(state, skillInfo, clonedE);
-    if (!filterResult) {
-      continue;
-    }
-    (0, skill.action)(state, skillInfo, clonedE);
-    if (clonedE._immuneInfo) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
  * Remove an entity by its id from the given game state.
  * @param state The mutable game state draft.
  * @param id The id of the entity to remove.
@@ -1036,17 +1009,24 @@ export function sortDice(
   ]);
 }
 
+type TupleIndices<T extends readonly unknown[]> = Extract<
+  keyof T,
+  `${number}`
+> extends `${infer N extends number}`
+  ? N
+  : never;
+
 declare global {
   interface ReadonlyArray<T> {
     map<This extends readonly [unknown, unknown], U>(
       this: This,
-      fn: (v: T) => U,
+      fn: (value: T, index: TupleIndices<This>, array: This) => U,
     ): { -readonly [K in keyof This]: U };
   }
   interface Array<T> {
     map<This extends [unknown, unknown], U>(
       this: This,
-      fn: (v: T) => U,
+      fn: (value: T, index: TupleIndices<This>, array: This) => U,
     ): { -readonly [K in keyof This]: U };
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! To help us review your pull request more efficiently, please fill out the following sections:

- Clearly describe what you changed and why.
- Explain how you verified that your changes are correct.
-->

## What Changed

In this PR, we proposed the *Single Event List* finalization framework from @nana-nahida .

In this proposal, the Skill execution will typically be split into two parts:
1. The *termination processing* of each skill's execution: Combining damage events, dropping HCI events, inline-handling `modifyZeroHealth` and reorder.
2. The *recursion event handling* and defeated IO: calls to a `SkillExecutor#handleEvent` and checks defeated of active characters of players.

The two parts are separated by the sign of *gaining energy* for character skills. Everything before gaining energy is reorganized into the termination processing part.

The changes made by this PR:
- Move the `modifyZeroHealth` "shallow" handling into the termination process. This reuse the previous `StateMutator#executeInlineSkill`.
- The damage event merging was refactored to be happened immediately when the event is pushed into the event list. This is done by an extended `Array` class `EventList` with overriden `push` operation. This refactor makes `executeInlineSkill` of `modifyZeroHealth` more easy to handle.
- The event reordering was moved into the termination process too.
- Fixed some TypeScript error created by #699 .

## How to Prove It Works

All previous UTs, including HCI orders, defeated handlings and damage mergings still passed.

<!-- Explain how you tested your changes. Did you run unit tests, integration tests, or manual verifications? Please provide steps or evidence that demonstrate your change is correct. -->
