### PR TITLE
refactor(core, data): fix entity triggering on defeated characters

### DIFF
--- a/packages/core/src/base/entity.ts
+++ b/packages/core/src/base/entity.ts
@@ -89,6 +89,7 @@ export interface EntityDefinition {
   readonly disableTuning: boolean;
   readonly varConfigs: EntityVariableConfigs;
   readonly disposeWhenUsageIsZero: boolean;
+  readonly disposeOnMasterDefeated: boolean;
   readonly skills: readonly SkillDefinition[];
   readonly descriptionDictionary: DescriptionDictionary;
 }

--- a/packages/core/src/builder/entity.ts
+++ b/packages/core/src/builder/entity.ts
@@ -143,12 +143,12 @@ export class EntityBuilder<
 > {
   private _skillNo = 0;
   readonly _skillList: SkillDefinition[] = [];
-  private _defaultDispose = true;
   _usagePerRoundIndex = 0;
   private readonly _tags: (EntityTag | AttachmentTag)[] = [];
   _varConfigs: Writable<EntityVariableConfigs> = {};
   _obtainable = false;
   private _disposeWhenUsageIsZero = false;
+  private _disposeOnMasterDefeated: boolean;
   private _visibleVarName: string | null = null;
   _associatedExtensionId: number | null = null;
   private _hintText: string | null = null;
@@ -166,6 +166,15 @@ export class EntityBuilder<
     private readonly chainFromId: number | null = null,
   ) {
     builderWeakRefs.add(new WeakRef(this));
+    this._disposeOnMasterDefeated = _type === "status" || _type === "equipment";
+    this.on(
+      "defeated",
+      (c, e) =>
+        c.self.area.type === "characters" &&
+        c.self.cast<EntityType>().definition.disposeOnMasterDefeated,
+    )
+      .dispose()
+      .endOn();
   }
 
   noDefaultDispose() {
@@ -174,7 +183,7 @@ export class EntityBuilder<
         `Only status and equipment can specify .noDefaultDispose()`,
       );
     }
-    this._defaultDispose = false;
+    this._disposeOnMasterDefeated = false;
     return this;
   }
 
@@ -786,13 +795,6 @@ export class EntityBuilder<
         .endOn();
     }
 
-    if (
-      (this._type === "status" || this._type === "equipment") &&
-      this._defaultDispose
-    ) {
-      this.on("defeated").dispose().endOn();
-    }
-
     const skills = [...this._skillList];
     if (this._type === "character") {
       registerPassiveSkill({
@@ -825,6 +827,7 @@ export class EntityBuilder<
         visibleVarName: this._visibleVarName,
         varConfigs: this._varConfigs,
         disposeWhenUsageIsZero: this._disposeWhenUsageIsZero,
+        disposeOnMasterDefeated: this._disposeOnMasterDefeated,
         hintText: this._hintText,
         disableTuning: false,
         skills,
@@ -841,7 +844,9 @@ export class EntityBuilder<
   }
 
   protected getAttachmentModifications(): ModificationGetter {
-    throw new GiTcgCoreInternalError(`Unreachable; AttachmentBuilder should override this`);
+    throw new GiTcgCoreInternalError(
+      `Unreachable; AttachmentBuilder should override this`,
+    );
   }
 
   /** 此定义未被使用。 */

--- a/packages/core/src/builder/entity.ts
+++ b/packages/core/src/builder/entity.ts
@@ -167,14 +167,21 @@ export class EntityBuilder<
   ) {
     builderWeakRefs.add(new WeakRef(this));
     this._disposeOnMasterDefeated = _type === "status" || _type === "equipment";
-    this.on(
+    this.createDefaultDisposeSkill();
+  }
+
+  private createDefaultDisposeSkill() {
+    if (!(this._type === "status" || this._type === "equipment")) {
+      return;
+    }
+    const builder = this.on(
       "defeated",
       (c, e) =>
         c.self.area.type === "characters" &&
         c.self.cast<EntityType>().definition.disposeOnMasterDefeated,
-    )
-      .dispose()
-      .endOn();
+    );
+    builder["~isDefaultDefeatedDispose"] = true;
+    builder.dispose().endOn();
   }
 
   noDefaultDispose() {

--- a/packages/core/src/builder/entity.ts
+++ b/packages/core/src/builder/entity.ts
@@ -144,7 +144,6 @@ export class EntityBuilder<
   private _skillNo = 0;
   readonly _skillList: SkillDefinition[] = [];
   private _defaultDispose = true;
-  readonly _skillListBeforeDefaultDispose: SkillDefinition[] = [];
   _usagePerRoundIndex = 0;
   private readonly _tags: (EntityTag | AttachmentTag)[] = [];
   _varConfigs: Writable<EntityVariableConfigs> = {};
@@ -609,13 +608,6 @@ export class EntityBuilder<
     return this.hintIcon(icon);
   }
 
-  onMasterDefeated() {
-    if (this._type === "status" || this._type === "equipment") {
-      return this.on("defeated").beforeDefaultDispose();
-    } else {
-      throw new GiTcgDataError("Type error when onMasterDefeated");
-    }
-  }
   /**
    * Same as
    * ```
@@ -798,10 +790,10 @@ export class EntityBuilder<
       (this._type === "status" || this._type === "equipment") &&
       this._defaultDispose
     ) {
-      this.onMasterDefeated().dispose().endOn();
+      this.on("defeated").dispose().endOn();
     }
 
-    const skills = [...this._skillListBeforeDefaultDispose, ...this._skillList];
+    const skills = [...this._skillList];
     if (this._type === "character") {
       registerPassiveSkill({
         __definition: "passiveSkills",

--- a/packages/core/src/builder/skill.ts
+++ b/packages/core/src/builder/skill.ts
@@ -1064,11 +1064,10 @@ export class TriggeredSkillBuilder<
     ) {
       this.filters.push((c) => c.self.variables.alive);
     }
-    // 3. 状态和装备的技能默认要求角色存活，击倒默认弃置和响应自身弃置除外
+    // 3. 状态和装备的技能默认要求角色存活，默认击倒弃置除外
     if (
       !this["~isDefaultDefeatedDispose"] &&
-      (this.parent._type === "status" || this.parent._type === "equipment") &&
-      this.detailedEventName !== "selfDispose"
+      (this.parent._type === "status" || this.parent._type === "equipment")
     ) {
       this.filters.push((c) => {
         if (c.self.area.type === "characters") {

--- a/packages/core/src/builder/skill.ts
+++ b/packages/core/src/builder/skill.ts
@@ -1044,14 +1044,6 @@ export class TriggeredSkillBuilder<
     ) {
       this.filters.push((c) => c.self.variables.alive);
     }
-    if (
-      (this.parent._type === "status" || this.parent._type === "equipment") &&
-      this.detailedEventName !== "selfDispose"
-    ) {
-      this.filters.push(
-        (c) => c.self.cast<"status" | "equipment">().master.variables.alive,
-      );
-    }
     // 1. 对于并非响应自身弃置的技能，当实体已经被弃置时，不再响应
     if (this.detailedEventName !== "selfDispose") {
       this.filters.push((c, e) => {
@@ -1069,7 +1061,20 @@ export class TriggeredSkillBuilder<
         return c.self.area.type !== "pile";
       });
     }
-    // 3. 基于 listenTo 的 filter
+    // 3. 状态和装备的技能默认要求角色存活，击倒默认弃置和响应自身弃置除外
+    if (
+      (this.parent._type === "status" || this.parent._type === "equipment") &&
+      this.detailedEventName !== "selfDispose" &&
+      this.detailedEventName !== "defeated"
+    ) {
+      this.filters.push((c) => {
+        if (c.self.area.type === "characters") {
+          return c.self.cast<"status" | "equipment">().master.variables.alive;
+        }
+        return true;
+      });
+    }
+    // 4. 基于 listenTo 的 filter
     const [triggerOn, filterDescriptor] =
       detailedEventDictionary[
         isCustomEvent(this.detailedEventName)
@@ -1089,7 +1094,7 @@ export class TriggeredSkillBuilder<
         c.rawState,
       );
     });
-    // 4. 自定义事件：确保事件名一致
+    // 5. 自定义事件：确保事件名一致
     if (isCustomEvent(this.detailedEventName)) {
       const customEvent = this.detailedEventName;
       this.filters.push(function (c, e) {
@@ -1098,7 +1103,7 @@ export class TriggeredSkillBuilder<
         );
       });
     }
-    // 5. 定义技能时显式传入的 filter
+    // 6. 定义技能时显式传入的 filter
     this.filters.push(this.triggerFilter);
 
     const parentSkillList = this.parent._skillList;

--- a/packages/core/src/builder/skill.ts
+++ b/packages/core/src/builder/skill.ts
@@ -873,7 +873,6 @@ export class TriggeredSkillBuilder<
   CreateSkillBuilderMeta<EventArgType, CallerType, CallerVars, AssociatedExt>
 > {
   private _asSkillType: CommonSkillType | null = null;
-  private _beforeDefaultDispose = false;
   private _enableHandTriggering = false;
   private _enablePileTriggering = false;
   private _usageOpt: { name: string; autoDecrease: boolean } | null = null;
@@ -915,11 +914,6 @@ export class TriggeredSkillBuilder<
       );
     }
     this._asSkillType = skillType;
-    return this;
-  }
-
-  beforeDefaultDispose() {
-    this._beforeDefaultDispose = true;
     return this;
   }
 
@@ -994,16 +988,10 @@ export class TriggeredSkillBuilder<
     return this;
   }
   listenToPlayer(): this {
-    if (this._beforeDefaultDispose) {
-      throw new GiTcgDataError("Only not self defeated can be listened");
-    }
     this._listenTo = ListenTo.SamePlayer;
     return this;
   }
   listenToAll(): this {
-    if (this._beforeDefaultDispose) {
-      throw new GiTcgDataError("Only not self defeated can be listened");
-    }
     this._listenTo = ListenTo.All;
     return this;
   }
@@ -1056,6 +1044,14 @@ export class TriggeredSkillBuilder<
     ) {
       this.filters.push((c) => c.self.variables.alive);
     }
+    if (
+      (this.parent._type === "status" || this.parent._type === "equipment") &&
+      this.detailedEventName !== "selfDispose"
+    ) {
+      this.filters.push(
+        (c) => c.self.cast<"status" | "equipment">().master.variables.alive,
+      );
+    }
     // 1. 对于并非响应自身弃置的技能，当实体已经被弃置时，不再响应
     if (this.detailedEventName !== "selfDispose") {
       this.filters.push((c, e) => {
@@ -1105,9 +1101,7 @@ export class TriggeredSkillBuilder<
     // 5. 定义技能时显式传入的 filter
     this.filters.push(this.triggerFilter);
 
-    const parentSkillList = this._beforeDefaultDispose
-      ? this.parent._skillListBeforeDefaultDispose
-      : this.parent._skillList;
+    const parentSkillList = this.parent._skillList;
 
     // 【构造技能定义并向父级实体添加】
     const filter = this.buildFilter();

--- a/packages/core/src/builder/skill.ts
+++ b/packages/core/src/builder/skill.ts
@@ -882,7 +882,7 @@ export class TriggeredSkillBuilder<
   } | null = null;
   private _listenTo: ListenTo = ListenTo.SameArea;
 
-  /** @internal 这个技能是默认的角色击倒时弃置，不添加 filter */
+  /** @internal 这个技能是默认的角色击倒时弃置，不应用检测 master 存活的 filter */
   "~isDefaultDefeatedDispose" = false;
 
   constructor(

--- a/packages/core/src/builder/skill.ts
+++ b/packages/core/src/builder/skill.ts
@@ -882,6 +882,9 @@ export class TriggeredSkillBuilder<
   } | null = null;
   private _listenTo: ListenTo = ListenTo.SameArea;
 
+  /** @internal 这个技能是默认的角色击倒时弃置，不添加 filter */
+  "~isDefaultDefeatedDispose" = false;
+
   constructor(
     id: number,
     private readonly detailedEventName: DetailedEventNames | CustomEvent,
@@ -1037,20 +1040,13 @@ export class TriggeredSkillBuilder<
 
     // 【添加各种 filter】
 
-    // 0. 被动技能要求角色存活
-    if (
-      this.parent._type === "character" &&
-      this.detailedEventName !== "defeated"
-    ) {
-      this.filters.push((c) => c.self.variables.alive);
-    }
-    // 1. 对于并非响应自身弃置的技能，当实体已经被弃置时，不再响应
+    // 0. 对于并非响应自身弃置的技能，当实体已经被弃置时，不再响应
     if (this.detailedEventName !== "selfDispose") {
       this.filters.push((c, e) => {
         return c.self.area.type !== "removedEntities";
       });
     }
-    // 2. 默认禁止手牌区实体响应事件，除非显式启用
+    // 1. 默认禁止手牌 & 牌库区实体响应事件，除非显式启用
     if (!this._enableHandTriggering) {
       this.filters.push((c) => {
         return c.self.area.type !== "hands";
@@ -1061,11 +1057,18 @@ export class TriggeredSkillBuilder<
         return c.self.area.type !== "pile";
       });
     }
+    // 2. 被动技能要求角色存活
+    if (
+      this.parent._type === "character" &&
+      this.detailedEventName !== "defeated"
+    ) {
+      this.filters.push((c) => c.self.variables.alive);
+    }
     // 3. 状态和装备的技能默认要求角色存活，击倒默认弃置和响应自身弃置除外
     if (
+      !this["~isDefaultDefeatedDispose"] &&
       (this.parent._type === "status" || this.parent._type === "equipment") &&
-      this.detailedEventName !== "selfDispose" &&
-      this.detailedEventName !== "defeated"
+      this.detailedEventName !== "selfDispose"
     ) {
       this.filters.push((c) => {
         if (c.self.area.type === "characters") {

--- a/packages/data/src/characters/dendro/nahida.ts
+++ b/packages/data/src/characters/dendro/nahida.ts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { character, skill, status, combatStatus, card, DamageType, StatusHandle, customEvent } from "@gi-tcg/core/builder";
+import { character, skill, status, combatStatus, card, DamageType, StatusHandle, customEvent, $ } from "@gi-tcg/core/builder";
 
 // 蕴种印描述修正：
 // 入场时，此牌携带3点可用次数。可用次数耗尽时，弃置此牌。
@@ -33,13 +33,15 @@ export const TriggerOtherSeed = customEvent("nahida/triggerOtherSeed");
 export const SeedOfSkandha: StatusHandle = status(117031)
   .usage(2)
   .on("damaged", (c, e) => e.getReaction() !== null)
-  .beforeDefaultDispose()
   .do((c) => {
     if (
       // 由于蕴种印在对方场上，故查找我方信息时使用 opp
-      c.$("opp characters has equipment with definition id 217031") && // 装备有心识蕴藏之种
-      c.$("opp combat status with definition id 117032") && // 摩耶之殿在场时
-      c.$("opp characters include defeated with tag (pyro)") // 我方队伍中存在火元素
+      c.query($.opp.typeEquipment.def(TheSeedOfStoredKnowledge)) && // 装备有心识蕴藏之种
+      (
+        c.query($.opp.combatStatus.def(ShrineOfMaya)) ||
+        c.query($.opp.combatStatus.def(ShrineOfMaya01))
+      ) &&                                                          // 摩耶之殿在场时
+      c.query($.opp.character.includesDefeated.tag("pyro"))         // 我方队伍中存在火元素
     ) {
       c.damage(DamageType.Dendro, 1, "@master")
     } else {
@@ -52,6 +54,18 @@ export const SeedOfSkandha: StatusHandle = status(117031)
   .listenToPlayer()
   .damage(DamageType.Piercing, 1, "@master")
   .consumeUsage()
+  // 自身因元素反应伤害击倒而弃置时
+  .on("selfDispose", (c, e) => {
+    if (e.from.type !== "characters") {
+      return;
+    }
+    const fromChId = e.from.characterId;
+    if (c.get(fromChId).variables.alive) {
+      return;
+    }
+    return c.hasPhaseDamage("all", (e) => e.getReaction() !== null && e.damageInfo.target.id === fromChId);
+  })
+  .emitCustomEvent(TriggerOtherSeed)
   .done();
 
 /**

--- a/packages/data/src/characters/dendro/nahida.ts
+++ b/packages/data/src/characters/dendro/nahida.ts
@@ -63,7 +63,11 @@ export const SeedOfSkandha: StatusHandle = status(117031)
     if (c.get(fromChId).variables.alive) {
       return;
     }
-    return c.hasPhaseDamage("all", (e) => e.getReaction() !== null && e.damageInfo.target.id === fromChId);
+    return c.hasPhaseDamage("all", (e) =>
+      e.getReaction() !== null && 
+      e.damageInfo.causeDefeated && 
+      e.damageInfo.target.id === fromChId
+    );
   })
   .emitCustomEvent(TriggerOtherSeed)
   .done();

--- a/packages/data/src/characters/electro/abyss_lector_violet_lightning.ts
+++ b/packages/data/src/characters/electro/abyss_lector_violet_lightning.ts
@@ -155,7 +155,7 @@ export const AbyssLectorVioletLightning = character(2406)
   .skills(DenOfThunder, ShockOfTheEnigmaticAbyss, WildThunderburst, ElectricRebirthPassive)
   .done();
 
-// 侵雷重闪入场时创建此出战状态，检测咏者击倒后失去1点充能
+// 侵雷重闪入场时创建此出战状态，检测咏者击倒后夺取1点充能
 export const ChainLightningCascadeCombatStatus = combatStatus(124065)
   .on("defeated", (c, e) => e.target.definition.id === AbyssLectorVioletLightning)
   .do((c) => {

--- a/packages/data/src/characters/electro/abyss_lector_violet_lightning.ts
+++ b/packages/data/src/characters/electro/abyss_lector_violet_lightning.ts
@@ -155,6 +155,7 @@ export const AbyssLectorVioletLightning = character(2406)
   .skills(DenOfThunder, ShockOfTheEnigmaticAbyss, WildThunderburst, ElectricRebirthPassive)
   .done();
 
+// 侵雷重闪入场时创建此出战状态，检测咏者击倒后失去1点充能
 export const ChainLightningCascadeCombatStatus = combatStatus(124065)
   .on("defeated", (c, e) => e.target.definition.id === AbyssLectorVioletLightning)
   .do((c) => {

--- a/packages/data/src/characters/electro/abyss_lector_violet_lightning.ts
+++ b/packages/data/src/characters/electro/abyss_lector_violet_lightning.ts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { character, skill, status, card, DamageType, Aura } from "@gi-tcg/core/builder";
+import { character, skill, status, card, DamageType, Aura, combatStatus, $ } from "@gi-tcg/core/builder";
 
 /**
  * @id 124063
@@ -155,6 +155,14 @@ export const AbyssLectorVioletLightning = character(2406)
   .skills(DenOfThunder, ShockOfTheEnigmaticAbyss, WildThunderburst, ElectricRebirthPassive)
   .done();
 
+export const ChainLightningCascadeCombatStatus = combatStatus(124065)
+  .on("defeated", (c, e) => e.target.definition.id === AbyssLectorVioletLightning)
+  .do((c) => {
+    c.query($.opp.active)?.loseEnergy(1);
+    c.dispose();
+  })
+  .done();
+
 /**
  * @id 224061
  * @name 侵雷重闪
@@ -169,13 +177,9 @@ export const ChainLightningCascade = card(224061)
   .talent(AbyssLectorVioletLightning, "none")
   .on("enter")
   .do((c) => {
+    c.combatStatus(ChainLightningCascadeCombatStatus);
     if (!c.self.master.hasStatus(ElectricRebirth)) {
-      c.$("opp active")?.loseEnergy(1);
+      c.query($.opp.active)?.loseEnergy(1);
     }
-  })
-  .endOn()
-  .onMasterDefeated()
-  .do((c) => {
-    c.$("opp active")?.loseEnergy(1);
   })
   .done();

--- a/packages/data/src/characters/hydro/abyss_herald_wicked_torrents.ts
+++ b/packages/data/src/characters/hydro/abyss_herald_wicked_torrents.ts
@@ -192,6 +192,12 @@ export const AbyssHeraldWickedTorrents = character(2203)
   .skills(RipplingSlash, VortexEdge, TorrentialShock, WateryRebirth, RipplingBlades, WateryRebirth01)
   .done();
 
+export const SurgingUndercurrentCombatStatus = combatStatus(122034)
+  .on("defeated", (c, e) => e.target.definition.id === AbyssHeraldWickedTorrents)
+  .combatStatus(CurseOfTheUndercurrent, "opp")
+  .dispose()
+  .done();
+
 /**
  * @id 222031
  * @name 暗流涌动
@@ -205,8 +211,6 @@ export const SurgingUndercurrent = card(222031)
   .costHydro(1)
   .talent(AbyssHeraldWickedTorrents, "none")
   .on("enter", (c) => c.self.master.getVariable("wateryRebirthTriggered"))
-  .combatStatus(CurseOfTheUndercurrent, "opp")
-  .endOn()
-  .onMasterDefeated()
+  .combatStatus(SurgingUndercurrentCombatStatus)
   .combatStatus(CurseOfTheUndercurrent, "opp")
   .done();

--- a/packages/data/src/characters/hydro/abyss_herald_wicked_torrents.ts
+++ b/packages/data/src/characters/hydro/abyss_herald_wicked_torrents.ts
@@ -192,6 +192,7 @@ export const AbyssHeraldWickedTorrents = character(2203)
   .skills(RipplingSlash, VortexEdge, TorrentialShock, WateryRebirth, RipplingBlades, WateryRebirth01)
   .done();
 
+// 暗流涌动入场时创建此出战状态，检测使徒击倒后生成暗流的诅咒
 export const SurgingUndercurrentCombatStatus = combatStatus(122034)
   .on("defeated", (c, e) => e.target.definition.id === AbyssHeraldWickedTorrents)
   .combatStatus(CurseOfTheUndercurrent, "opp")
@@ -210,7 +211,11 @@ export const SurgingUndercurrent = card(222031)
   .since("v4.6.0")
   .costHydro(1)
   .talent(AbyssHeraldWickedTorrents, "none")
-  .on("enter", (c) => c.self.master.getVariable("wateryRebirthTriggered"))
-  .combatStatus(SurgingUndercurrentCombatStatus)
-  .combatStatus(CurseOfTheUndercurrent, "opp")
+  .on("enter")
+  .do((c) => {
+    c.combatStatus(SurgingUndercurrentCombatStatus);
+    if (c.self.master.getVariable("wateryRebirthTriggered")) {
+      c.combatStatus(CurseOfTheUndercurrent, "opp");
+    }
+  })
   .done();

--- a/packages/data/src/characters/hydro/tartaglia.ts
+++ b/packages/data/src/characters/hydro/tartaglia.ts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { character, skill, status, card, DamageType, StatusHandle, combatStatus } from "@gi-tcg/core/builder";
+import { character, skill, status, card, DamageType, StatusHandle, combatStatus, $ } from "@gi-tcg/core/builder";
 
 /**
  * @id 112042
@@ -56,10 +56,13 @@ export const RangedStance = status(112041)
  * （处于「近战状态」的达达利亚攻击所附属角色时，会造成额外伤害。）
  */
 export const Riptide: StatusHandle = status(112043)
-  .onMasterDefeated()
+  // 当带有断流的角色被击倒时（也即断流弃置时）：
+  // - 若出战角色被击倒（稍后玩家需选择出战）： 则在下次切换角色后，为新的出战角色附属断流。
+  // - 否则直接为当前出战角色附属断流。
+  .on("selfDispose")
   .do((c) => {
-    const active = c.$("my active includes defeated")!;
-    if (active.variables.alive) {
+    const active = c.query($.my.active.includesDefeated);
+    if (active?.variables.alive) {
       active.addStatus(Riptide);
     } else {
       c.combatStatus(Riptide2);
@@ -67,18 +70,10 @@ export const Riptide: StatusHandle = status(112043)
   })
   .done();
 
-
-// 当对方带有断流的角色被击倒时：
-// 若出战角色被击倒（稍后玩家需选择出战角色）：
-// - 则在下次切换角色后，为新的出战角色附属断流。
-// 否则：
-// - 直接为当前出战角色附属断流。
-
 const Riptide2 = combatStatus(112044)
   .once("switchActive")
   .characterStatus(Riptide, "my active")
   .done();
-
 
 /**
  * @id 12041

--- a/packages/test/__tests__/abyss_lector_violet_lightning.test.tsx
+++ b/packages/test/__tests__/abyss_lector_violet_lightning.test.tsx
@@ -1,0 +1,48 @@
+// Copyright (C) 2026 Piovium Labs
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { ref, setup, Character, State, Card, $, Status } from "#test";
+import { TandooriRoastChicken } from "@gi-tcg/data/internal/cards/event/food";
+import { AbyssLectorVioletLightning, ChainLightningCascade, ElectricRebirth, ElectricRebirthHoned } from "@gi-tcg/data/internal/characters/electro/abyss_lector_violet_lightning";
+import { JadeScreen, Ningguang, SparklingScatter } from "@gi-tcg/data/internal/characters/geo/ningguang";
+import { test } from "bun:test";
+
+test("electro abyss talent: triggered on defeated", async () => {
+  const abyss = ref();
+  const c = setup(
+    <State>
+      <Card opp def={TandooriRoastChicken} />
+      <Character opp active def={Ningguang} energy={2} />
+      <Character my active def={AbyssLectorVioletLightning} health={1} ref={abyss} >
+        <Status def={ElectricRebirth} />
+      </Character>
+      <Card my def={ChainLightningCascade} />
+    </State>
+  );
+  await c.me.card(ChainLightningCascade, abyss);
+  await c.me.end();
+  // 打出复活甲
+  await c.opp.skill(SparklingScatter);
+  c.expect(abyss).toHaveVariable({ health: 4 });
+  c.expect($.my.typeStatus.def(ElectricRebirthHoned)).toBeExist();
+  // 被夺取一点充能
+  c.expect($.opp.active).toHaveVariable({ energy: 2 });
+  await c.opp.card(TandooriRoastChicken);
+  // 2+2 打 4
+  await c.opp.skill(JadeScreen);
+  c.expect(abyss).toHaveVariable({ alive: 0 });
+  // 被夺取一点充能
+  c.expect($.opp.active).toHaveVariable({ energy: 2 });
+})

--- a/packages/test/__tests__/tartaglia.test.tsx
+++ b/packages/test/__tests__/tartaglia.test.tsx
@@ -32,10 +32,5 @@ test("riptide should propagate", async () => {
   );
   await c.me.skill(YunlaiSwordsmanship);
   await c.opp.chooseActive(oppNext);
-
-
-  console.dir(c.game.detailLog, { depth: null });
-
-
   c.expect($.typeStatus.def(Riptide).at($.id(oppNext.id))).toBeExist();
 });

--- a/packages/test/__tests__/tartaglia.test.tsx
+++ b/packages/test/__tests__/tartaglia.test.tsx
@@ -32,5 +32,10 @@ test("riptide should propagate", async () => {
   );
   await c.me.skill(YunlaiSwordsmanship);
   await c.opp.chooseActive(oppNext);
+
+
+  console.dir(c.game.detailLog, { depth: null });
+
+
   c.expect($.typeStatus.def(Riptide).at($.id(oppNext.id))).toBeExist();
 });


### PR DESCRIPTION
## What Changed

Fixes #500 (planned).

- [x] Remove configuration around "default dispose"; the default dispose is harden configured via `.noDefaultDispose()` and cannot be overiden by custom handlers of `on("defeated")`
- [x] Disable triggered skills on defeated characters
- [x] Fix Nahida's `Seed of Skandha`
- [x] Fix Tartaglia's `Riptide`
- [x] Fix Abyss Herald Wicked Torrents's talent (via hidden combat status)
- [x] Fix Abyss Lector Violet Lightning's talent (via hidden combat status)

## How to Prove It Works

Tests around Nahida, Tartaglia works, and add a new test for Abyss 