### PR TITLE
feat(server): upload room game log to s3

### DIFF
--- a/packages/server/src/rooms/rooms.service.ts
+++ b/packages/server/src/rooms/rooms.service.ts
@@ -429,8 +429,8 @@ class Room {
   private stateLog: GameStateLogEntry[] = [];
   private terminated = false;
   private onStopHandlers: GameStopHandler[] = [];
-  private startedAt: string | null = null;
-  private endedAt: string | null = null;
+  private startedAt: Date | null = null;
+  private endedAt: Date | null = null;
 
   constructor(
     public readonly id: number,
@@ -504,7 +504,7 @@ class Room {
         `Failed to create initial game state: ${e}; propably due to invalid decks`,
       );
     }
-    this.startedAt = new Date().toISOString();
+    this.startedAt = new Date();
     const game = new InternalGame(state);
     game.onPause = async (state, mutations, canResume) => {
       this.stateLog.push({ state, canResume });
@@ -560,7 +560,7 @@ class Room {
 
   stop() {
     this.terminated = true;
-    this.endedAt = new Date().toISOString();
+    this.endedAt = new Date();
     this.players[0]?.complete();
     this.players[1]?.complete();
     for (const cb of this.onStopHandlers) {
@@ -584,8 +584,8 @@ class Room {
       gv: this.config.gameVersion,
       m: {
         roomId: this.id,
-        startedAt: this.startedAt,
-        endedAt: this.endedAt,
+        startedAt: this.startedAt?.toISOString() ?? null,
+        endedAt: this.endedAt?.toISOString() ?? null,
         players,
       },
     };

--- a/packages/server/src/rooms/rooms.service.ts
+++ b/packages/server/src/rooms/rooms.service.ts
@@ -71,7 +71,7 @@ import type {
 import { DecksService } from "../decks/decks.service";
 import { UsersService, type UserInfo } from "../users/users.service";
 import { GamesService } from "../games/games.service";
-import { redis, semver } from "bun";
+import { redis, s3, semver } from "bun";
 
 interface RoomConfig extends Partial<GameConfig> {
   initTotalActionTime: number; // defaults 45
@@ -915,13 +915,27 @@ export class RoomsService {
       ) as number[];
       const winnerWho = game.state.winner;
       const winnerId = winnerWho === null ? null : playerIds[winnerWho]!;
+      const gameData = JSON.stringify(room.getStateLog());
       this.games.addGame({
         coreVersion: Room.CORE_VERSION,
         gameVersion: room.config.gameVersion,
-        data: JSON.stringify(room.getStateLog()),
+        data: gameData,
         winnerId,
         playerIds,
       });
+      if (process.env.S3_BUCKET) {
+        const now = new Date().toISOString();
+        const date = now.slice(0, 10);
+        const time = now.slice(11, 19).replaceAll(":", "");
+        s3
+          .file(`logs/${date}/${time}-${room.id}.json`)
+          .write(gameData, { type: "application/json" })
+          .catch((error) => {
+            this.logger.warn(
+              `Failed to upload room ${room.id} game log: ${error}`,
+            );
+          });
+      }
     });
     room.start();
     this.metrics.incrementStartedRooms();

--- a/packages/server/src/rooms/rooms.service.ts
+++ b/packages/server/src/rooms/rooms.service.ts
@@ -429,6 +429,8 @@ class Room {
   private stateLog: GameStateLogEntry[] = [];
   private terminated = false;
   private onStopHandlers: GameStopHandler[] = [];
+  private startedAt: string | null = null;
+  private endedAt: string | null = null;
 
   constructor(
     public readonly id: number,
@@ -502,6 +504,7 @@ class Room {
         `Failed to create initial game state: ${e}; propably due to invalid decks`,
       );
     }
+    this.startedAt = new Date().toISOString();
     const game = new InternalGame(state);
     game.onPause = async (state, mutations, canResume) => {
       this.stateLog.push({ state, canResume });
@@ -557,6 +560,7 @@ class Room {
 
   stop() {
     this.terminated = true;
+    this.endedAt = new Date().toISOString();
     this.players[0]?.complete();
     this.players[1]?.complete();
     for (const cb of this.onStopHandlers) {
@@ -569,9 +573,21 @@ class Room {
   }
 
   getStateLog() {
+    const players = ([0, 1] as const)
+      .map((who) => {
+        const player = this.getPlayer(who)?.playerInfo;
+        return player && { who, id: player.id, name: player.name };
+      })
+      .filter((player): player is NonNullable<typeof player> => !!player);
     return {
       ...serializeGameStateLog(this.stateLog),
       gv: this.config.gameVersion,
+      m: {
+        roomId: this.id,
+        startedAt: this.startedAt,
+        endedAt: this.endedAt,
+        players,
+      },
     };
   }
 

--- a/packages/server/src/rooms/rooms.service.ts
+++ b/packages/server/src/rooms/rooms.service.ts
@@ -577,8 +577,7 @@ class Room {
       .map((who) => {
         const player = this.getPlayer(who)?.playerInfo;
         return player && { who, id: player.id, name: player.name };
-      })
-      .filter((player): player is NonNullable<typeof player> => !!player);
+      });
     return {
       ...serializeGameStateLog(this.stateLog),
       gv: this.config.gameVersion,

--- a/packages/server/src/rooms/rooms.service.ts
+++ b/packages/server/src/rooms/rooms.service.ts
@@ -907,6 +907,22 @@ export class RoomsService {
         return;
       }
       const players = room.getPlayers();
+      const gameData = JSON.stringify(room.getStateLog());
+      if (process.env.S3_BUCKET) {
+        const now = new Date().toISOString();
+        const date = now.slice(0, 10);
+        const time = now.slice(11, 19).replaceAll(":", "");
+        const s3Prefix = process.env.S3_PREFIX;
+        const keyPrefix = s3Prefix ? `${s3Prefix}/` : "";
+        s3
+          .file(`${keyPrefix}logs/${date}/${time}-${room.id}.json`)
+          .write(gameData, { type: "application/json" })
+          .catch((error) => {
+            this.logger.warn(
+              `Failed to upload room ${room.id} game log: ${error}`,
+            );
+          });
+      }
       if (players.some((p) => p.playerInfo.isGuest)) {
         return;
       }
@@ -915,7 +931,6 @@ export class RoomsService {
       ) as number[];
       const winnerWho = game.state.winner;
       const winnerId = winnerWho === null ? null : playerIds[winnerWho]!;
-      const gameData = JSON.stringify(room.getStateLog());
       this.games.addGame({
         coreVersion: Room.CORE_VERSION,
         gameVersion: room.config.gameVersion,
@@ -923,19 +938,6 @@ export class RoomsService {
         winnerId,
         playerIds,
       });
-      if (process.env.S3_BUCKET) {
-        const now = new Date().toISOString();
-        const date = now.slice(0, 10);
-        const time = now.slice(11, 19).replaceAll(":", "");
-        s3
-          .file(`logs/${date}/${time}-${room.id}.json`)
-          .write(gameData, { type: "application/json" })
-          .catch((error) => {
-            this.logger.warn(
-              `Failed to upload room ${room.id} game log: ${error}`,
-            );
-          });
-      }
     });
     room.start();
     this.metrics.incrementStartedRooms();


### PR DESCRIPTION
## Summary
- upload finished room game logs to S3 when `S3_BUCKET` is configured
- keep database and S3 payloads consistent by storing the same serialized game log in both places
- include lightweight metadata in `gameLog.m`, including room id, start/end timestamps, and player info
- upload guest game logs to S3 as well, while keeping database persistence restricted to non-guest games
- support an optional `S3_PREFIX` so different environments can write under different prefixes while preserving daily log lookup