### PR TITLE
fix(core): skill log should be reset after defeated

### DIFF
--- a/packages/core/src/base/mutation.ts
+++ b/packages/core/src/base/mutation.ts
@@ -210,6 +210,10 @@ export interface PushRoundSkillLogM {
   readonly caller: CharacterState;
   readonly skillId: number;
 }
+export interface RemoveRoundSkillLogM {
+  readonly type: "removeRoundSkillLog";
+  readonly caller: CharacterState;
+}
 export interface ClearRoundLogsM {
   readonly type: "clearRoundLogs";
 }
@@ -249,6 +253,7 @@ export type Mutation =
   | SetPlayerFlagM
   | MutateExtensionStateM
   | PushRoundSkillLogM
+  | RemoveRoundSkillLogM
   | ClearRoundLogsM
   | ClearRemovedEntitiesM
   | PushPhaseDamageLogM
@@ -517,6 +522,14 @@ function doMutation(state: GameState, m: Mutation): GameState {
         player.roundSkillLog.get(key)!.push(m.skillId);
       });
     }
+    case "removeRoundSkillLog": {
+      const key = m.caller.definition.id;
+      const { who } = getEntityArea(state, m.caller.id);
+      return produce(state, (draft) => {
+        const player = draft.players[who];
+        player.roundSkillLog.delete(key);
+      });
+    }
     case "clearRoundLogs": {
       return produce(state, (draft) => {
         draft.players[0].roundSkillLog.clear();
@@ -621,6 +634,11 @@ export function stringifyMutation(m: Mutation): string | null {
     }
     case "pushRoundSkillLog": {
       return `Push round skill log ${m.skillId} into ${stringifyState(
+        m.caller,
+      )}`;
+    }
+    case "removeRoundSkillLog": {
+      return `Remove round skill log of [character:${m.caller.definition.id}] from ${stringifyState(
         m.caller,
       )}`;
     }

--- a/packages/core/src/builder/context/skill.ts
+++ b/packages/core/src/builder/context/skill.ts
@@ -337,6 +337,10 @@ export class SkillContext<Meta extends ContextMetaBase> {
                 flagName: "hasDefeated",
                 value: true,
               });
+              this.mutate({
+                type: "removeRoundSkillLog",
+                caller: defeatedCh.latest(),
+              });
               const player = this.state.players[defeatedCh.who];
               const aliveCharacters = player.characters.filter(
                 (ch) => ch.variables.alive,

--- a/packages/core/src/io.ts
+++ b/packages/core/src/io.ts
@@ -239,6 +239,7 @@ export function exposeMutation(
     case "mutateExtensionState":
     case "clearRemovedEntities":
     case "pushRoundSkillLog":
+    case "removeRoundSkillLog":
     case "clearRoundLogs":
     case "pushPhaseDamageLog":
     case "pushPhaseReactionLog":

--- a/packages/data/src/characters/cryo/ganyu.ts
+++ b/packages/data/src/characters/cryo/ganyu.ts
@@ -71,6 +71,12 @@ export const TrailOfTheQilin = skill(11012)
 const FrostflakeArrowUsedExtension = extension(11013, { used: "pair<boolean>" })
   .initialState({ used: [false, false] })
   .description("本场对局中某方曾经使用过霜华矢")
+  .mutateWhen("onDamageOrHeal", (st, e) => {
+    // 甘雨倒下时重置
+    if (e.target.definition.id === Ganyu && e.damageInfo.causeDefeated) {
+      st.used[e.targetWho] = false;
+    }
+  })
   .done();
 
 /**

--- a/packages/data/src/characters/cryo/qiqi.ts
+++ b/packages/data/src/characters/cryo/qiqi.ts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { character, skill, summon, combatStatus, card, DamageType, SkillHandle } from "@gi-tcg/core/builder";
+import { character, skill, summon, combatStatus, card, DamageType, SkillHandle, extension, $ } from "@gi-tcg/core/builder";
 
 /**
  * @id 111081
@@ -76,6 +76,17 @@ export const AdeptusArtHeraldOfFrost: SkillHandle = skill(11082)
   .summon(HeraldOfFrost)
   .done();
 
+const RiteOfResurrectionUsedExtension = extension(211081, { count: "pair<number>" })
+  .initialState({ count: [0, 0] })
+  .description("本场对局中某方触发起死回骸的次数")
+  .mutateWhen("onDamageOrHeal", (st, e) => {
+    // 七七倒下时重置
+    if (e.target.definition.id === Qiqi && e.damageInfo.causeDefeated) {
+      st.count[e.targetWho] = 0;
+    }
+  })
+  .done();
+
 /**
  * @id 11083
  * @name 仙法·救苦度厄
@@ -86,8 +97,19 @@ export const AdeptusArtPreserverOfFortune: SkillHandle = skill(11083)
   .type("burst")
   .costCryo(3)
   .costEnergy(3)
-  .damage(DamageType.Cryo, 3)
-  .combatStatus(FortunepreservingTalisman)
+  .associateExtension(RiteOfResurrectionUsedExtension)
+  .do((c) => {
+    c.damage(DamageType.Cryo, 3);
+    c.combatStatus(FortunepreservingTalisman);
+    if (c.self.hasEquipment(RiteOfResurrection) && 
+      c.getExtensionState().count[c.self.who] < 2) {
+      c.setExtensionState((st) => st.count[c.self.who]++);
+      const defeated = c.queryAll($.my.character.onlyDefeated);
+      for (const ch of defeated) {
+        ch.heal(2, { kind: "revive" });
+      }
+    }
+  })
   .done();
 
 /**
@@ -120,11 +142,4 @@ export const RiteOfResurrection = card(211081)
   .talent(Qiqi)
   .on("enter")
   .useSkill(AdeptusArtPreserverOfFortune)
-  .on("useSkill", (c, e) => e.skill.definition.id === AdeptusArtPreserverOfFortune)
-  .usage(2, { autoDispose: false })
-  .do((c) => {
-    for (const ch of c.$$(`all my defeated characters`)) {
-      ch.heal(2, { kind: "revive" });
-    }
-  })
   .done();

--- a/packages/test/__tests__/ellin.test.tsx
+++ b/packages/test/__tests__/ellin.test.tsx
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 Piovium Labs
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { ref, setup, Character, State, Equipment, Card, Summon, CombatStatus, DeclaredEnd, Support, $, DiceCount } from "#test";
+import { TeyvatFriedEgg } from "@gi-tcg/data/internal/cards/event/food";
+import { Ellin } from "@gi-tcg/data/internal/cards/support/ally";
+import { CeremonialBladework, Kaeya } from "@gi-tcg/data/internal/characters/cryo/kaeya";
+import { AgileSwitch, EfficientSwitch } from "@gi-tcg/data/internal/commons";
+import { expect, test } from "bun:test";
+
+test("Ellin: discard records after characters defeated", async () => {
+  const kaeya = ref();
+  const myNext = ref();
+  const ellin = ref();
+  const c = setup(
+    <State>
+      <Character opp def={Kaeya} />
+      <Character my def={Kaeya} ref={kaeya} health={1} />
+      <Character my ref={myNext} />
+      <CombatStatus my def={AgileSwitch} />
+      <CombatStatus my def={EfficientSwitch} />
+      <Card my def={TeyvatFriedEgg} />
+      <Support my def={Ellin} ref={ellin} />
+    </State>
+  );
+  await c.me.skill(CeremonialBladework);
+  await c.opp.skill(CeremonialBladework);
+  await c.me.chooseActive(myNext);
+  await c.me.card(TeyvatFriedEgg, kaeya);
+  await c.me.switch(kaeya);
+  // 8 - 3 - 2
+  expect(c.state.players[0].dice).toBeArrayOfSize(3);
+  await c.me.skill(CeremonialBladework);
+  // 不触发减费
+  expect(c.state.players[0].dice).toBeArrayOfSize(0);
+  c.expect(ellin).toHaveVariable({ usagePerRound: 1 });
+});

--- a/packages/test/__tests__/ganyu.test.tsx
+++ b/packages/test/__tests__/ganyu.test.tsx
@@ -1,0 +1,49 @@
+// Copyright (C) 2026 Piovium Labs
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { ref, setup, Character, State, Equipment, Card, Summon, CombatStatus, DeclaredEnd, Support, $, DiceCount } from "#test";
+import { TeyvatFriedEgg } from "@gi-tcg/data/internal/cards/event/food";
+import { FrostflakeArrow, Ganyu, UndividedHeart } from "@gi-tcg/data/internal/characters/cryo/ganyu";
+import { CeremonialBladework, Kaeya } from "@gi-tcg/data/internal/characters/cryo/kaeya";
+import { AgileSwitch, EfficientSwitch } from "@gi-tcg/data/internal/commons";
+import { test } from "bun:test";
+
+test("ganyu: FrostflakeArrow usage clear after defeated", async () => {
+  const ganyu = ref();
+  const myNext = ref();
+  const c = setup(
+    <State>
+      <Character opp active health={10} def={Kaeya} />
+      <Character opp health={10} />
+      <Character opp health={10} />
+      <Character my active def={Ganyu} ref={ganyu} health={1} />
+      <Character my ref={myNext} />
+      <CombatStatus my def={AgileSwitch} />
+      <CombatStatus my def={EfficientSwitch} />
+      <Card my def={TeyvatFriedEgg} />
+      <Card my def={UndividedHeart} />
+      <DiceCount my count={12} />
+    </State>
+  );
+  await c.me.skill(FrostflakeArrow);
+  c.expect($.opp.next).toHaveVariable({ health: 8 });
+  await c.opp.skill(CeremonialBladework);
+  await c.me.chooseActive(myNext);
+  await c.me.card(TeyvatFriedEgg, ganyu);
+  await c.me.switch(ganyu);
+  await c.me.card(UndividedHeart, ganyu);
+  // 不触发天赋，仍然是后台-2
+  c.expect($.opp.next).toHaveVariable({ health: 6 });
+});

--- a/packages/test/src/setup.ts
+++ b/packages/test/src/setup.ts
@@ -171,6 +171,17 @@ export function DeclaredEnd(props: DeclaredEnd.Prop): JSX.Element {
   return { comp: DeclaredEnd, prop: props };
 }
 
+export namespace DiceCount {
+  export interface Prop {
+    my?: boolean;
+    opp?: boolean;
+    count: number;
+  }
+}
+export function DiceCount(props: DiceCount.Prop): JSX.Element {
+  return { comp: DiceCount, prop: props };
+}
+
 export namespace State {
   export interface Prop {
     dataVersion?: Version;
@@ -207,7 +218,7 @@ function emptyPlayerState(who: 0 | 1): Draft<PlayerState> {
     who,
     initialPile: [],
     pile: [],
-    dice: [],
+    dice: Array.from({ length: 8 }, () => DiceType.Omni),
     activeCharacterId: 0,
     characters: [],
     combatStatuses: [],
@@ -255,6 +266,15 @@ export function setup(state: JSX.Element): TestController {
       }
       if (prop.opp) {
         players[1].declaredEnd = true;
+      }
+      continue;
+    } else if (comp === DiceCount) {
+      const diceArr = Array.from({ length: prop.count }, () => DiceType.Omni);
+      if (prop.my) {
+        players[0].dice = diceArr;
+      }
+      if (prop.opp) {
+        players[1].dice = diceArr;
       }
       continue;
     }
@@ -489,7 +509,6 @@ export function setup(state: JSX.Element): TestController {
     if (player.activeCharacterId === 0) {
       player.activeCharacterId = player.characters[0].id;
     }
-    player.dice = Array.from({ length: 8 }, () => DiceType.Omni);
   }
 
   const extensions = data.extensions


### PR DESCRIPTION
<!--
Thank you for your contribution! To help us review your pull request more efficiently, please fill out the following sections:

- Clearly describe what you changed and why.
- Explain how you verified that your changes are correct.
-->

## What Changed

<!-- Describe the changes you made. What functionality, code, or files did you update? Why was this change necessary? -->

Fixes #709

`roundSkillLog` will remove one's entry when they are defeated.

Also modify `Ganyu` and `Qiqi`'s extension to match the defeated-reset behavior.

## How to Prove It Works

Add UT for this and Ganyu. (Qiqi's scenario is really rare and hard to write test setup)

<!-- Explain how you tested your changes. Did you run unit tests, integration tests, or manual verifications? Please provide steps or evidence that demonstrate your change is correct. -->
