### PR TITLE
fix(core): eneity oldversion

### DIFF
--- a/packages/core/src/builder/card.ts
+++ b/packages/core/src/builder/card.ts
@@ -462,12 +462,14 @@ export class CardBuilder<
     this.do((c) => {
       c.characterStatus(id as StatusHandle, target);
     }).done();
-    const builder = new EntityBuilder<"status", never, never, true, never>(
+    const builder = new EntityBuilder<
       "status",
-      id,
-      this.id,
-    );
-    builder._versionInfo = this._versionInfo;
+      never,
+      never,
+      true,
+      never
+    >("status", id, this.id);
+    builder._versionInfo = DEFAULT_VERSION_INFO;
     return builder;
   }
 


### PR DESCRIPTION
by kimi 2.6
修复完成。问题出在 packages/core/src/builder/card.ts:470 的 .toStatus() 方法：它会复制卡牌的版本信息（如 .until("v6.2.0")）给创建的状态，但状态缺少对应的 .since() 定义，导致版本解析器无法找到该状态定义。

修复方式：让 .toStatus() 创建的状态使用 DEFAULT_VERSION_INFO（即 since(INIT_VERSION)），使状态在所有版本中都可用。由于状态只能通过对应卡牌创建，而旧版卡牌只在对应版本可用，因此不会产生副作用。

改动文件：packages/core/src/builder/card.ts:470
