### PR TITLE
chore(ci): remove standalone vercel deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,26 +50,6 @@ jobs:
           name: csbinding-source
           path: packages/csbinding
 
-  Deploy-Frontend:
-    name: 🌐 Deploy Standalone Frontend
-    needs: Build-Core
-    runs-on: ubuntu-latest
-    env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_STANDALONE }}
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: standalone-frontend
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - name: Deploy to Vercel
-        run: >
-          bunx vercel deploy
-          ${{ github.ref == 'refs/heads/main' && '--prod' || '' }}
-          --token=${{ secrets.VERCEL_TOKEN }}
-
   Publish-Core:
     name: 🚀 Publish to npm (Tag Push)
     needs: Build-Core


### PR DESCRIPTION

<!--
Thank you for your contribution! To help us review your pull request more efficiently, please fill out the following sections:

- Clearly describe what you changed and why.
- Explain how you verified that your changes are correct.
-->

## What Changed


Deployment of standalone has been migrated to Railway.com and Vercel CI is not used anymore.

<!-- Describe the changes you made. What functionality, code, or files did you update? Why was this change necessary? -->

## How to Prove It Works

no need
<!-- Explain how you tested your changes. Did you run unit tests, integration tests, or manual verifications? Please provide steps or evidence that demonstrate your change is correct. -->
