### PR TITLE
fix(data): support increaseMaxHealth without healing

### DIFF
--- a/packages/core/src/builder/context/skill.ts
+++ b/packages/core/src/builder/context/skill.ts
@@ -165,6 +165,14 @@ export interface GenerateDiceOption {
   randomAllowDuplicate?: boolean;
 }
 
+export interface IncreaseMaxHealthOption {
+  /**
+   * 是否同时治疗
+   * @default true
+   */
+  heal?: boolean;
+}
+
 type Setter<T> = (draft: Draft<T>) => void;
 
 export type ContextMetaBase = {
@@ -853,13 +861,17 @@ export class SkillContext<Meta extends ContextMetaBase> {
   }
 
   /** 增加最大生命值 */
-  increaseMaxHealth(value: number, target: CharacterTargetArg) {
+  increaseMaxHealth(
+    value: number,
+    target: CharacterTargetArg,
+    { heal = true }: IncreaseMaxHealthOption = {},
+  ) {
     const targets = this.queryCoerceToCharacters(target);
     for (const t of targets) {
       const target = t.latest();
       using l = this.mutator.subLog(
         DetailLogType.Primitive,
-        `Increase ${value} max health to ${stringifyState(target)}`,
+        `Increase ${value} max health to ${stringifyState(target)} ${heal ? "and heal" : ""}`,
       );
       this.mutate({
         type: "modifyEntityVar",
@@ -868,11 +880,13 @@ export class SkillContext<Meta extends ContextMetaBase> {
         value: target.variables.maxHealth + value,
         direction: "increase",
       });
-      // t.latest() here for grabbing the new maxHealth
-      this.callAndEmit("heal", value, t.latest(), {
-        via: this.skillInfo,
-        kind: "increaseMaxHealth",
-      });
+      if (heal) {
+        // t.latest() here for grabbing the new maxHealth
+        this.callAndEmit("heal", value, t.latest(), {
+          via: this.skillInfo,
+          kind: "increaseMaxHealth",
+        });
+      }
     }
     return this.enableShortcut();
   }

--- a/packages/data/src/cards/support/adventure.ts
+++ b/packages/data/src/cards/support/adventure.ts
@@ -53,8 +53,8 @@ export const ChenyuVale = card(321032)
     if (!targetCh) {
       return;
     }
+    c.increaseMaxHealth(2, targetCh, { heal: false });
     c.heal(10, targetCh);
-    c.increaseMaxHealth(2, targetCh);
     c.finishAdventure();
   })
   .done();

--- a/packages/data/src/old_versions/v6.2.0.ts
+++ b/packages/data/src/old_versions/v6.2.0.ts
@@ -277,9 +277,9 @@ const ChenyuVale = card(321032)
     if (!targetCh) {
       return;
     }
+    c.increaseMaxHealth(2, targetCh, { heal: false });
     const healValue = 999; // interesting.
     c.heal(healValue, targetCh);
-    c.increaseMaxHealth(2, targetCh);
     c.finishAdventure();
   })
   .done();

--- a/packages/data/src/old_versions/v6.5.0.ts
+++ b/packages/data/src/old_versions/v6.5.0.ts
@@ -293,9 +293,9 @@ const ChenyuVale = card(321032)
     if (!targetCh) {
       return;
     }
+    c.increaseMaxHealth(2, targetCh, { heal: false });
     const healValue = 999; // interesting.
     c.heal(healValue, targetCh);
-    c.increaseMaxHealth(2, targetCh);
     c.finishAdventure();
   })
   .done();


### PR DESCRIPTION
<!--
Thank you for your contribution! To help us review your pull request more efficiently, please fill out the following sections:

- Clearly describe what you changed and why.
- Explain how you verified that your changes are correct.
-->

## What Changed

User reported that all version's Chenyu Vale increase max health first without healing, and then the heal (10 or 999).

Fixing introduce options towards `increaseMaxHealth`.

Fixes #730.

<!-- Describe the changes you made. What functionality, code, or files did you update? Why was this change necessary? -->

## How to Prove It Works

<!-- Explain how you tested your changes. Did you run unit tests, integration tests, or manual verifications? Please provide steps or evidence that demonstrate your change is correct. -->
