### PR TITLE
fix(server): dev import path

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -5,7 +5,7 @@
 ## 本地开发
 
 1. 安装依赖且构建所有依赖 packages（`core` `data` 等，可在根目录下执行 `pnpm build server` 以自动构建依赖）
-2. 创建 `.env` 文件，存储 `JWT_SECRET=任意字符串`。
+2. 在 `packages/server` 下创建 `.env` 文件，存储 `JWT_SECRET=任意字符串`。
 
    - 也可创建 `GH_CLIENT_ID` 与 `GH_CLIENT_SECRET` 以启用 GitHub OAuth 登录。此功能需要[新建 GitHub Apps](https://docs.github.com/en/apps/creating-github-apps)。
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -7,8 +7,7 @@
     "dev": "gnx ./src/dev.ts",
     "prisma:generate": "prisma generate",
     "build": "pnpm prisma:generate && gnx scripts/build.ts",
-    "start": "gnx src/main.ts",
-    "start:prod": "gnx dist/main.js",
+    "start": "gnx dist/main.js",
     "check": "tsc --noEmit",
     "debug": "nest start --debug --watch"
   },
@@ -49,6 +48,7 @@
     "@prisma/dev": "^0.24.7",
     "@swc/core": "^1.15.33",
     "@types/semver": "^7.7.1",
+    "dotenv": "^17.4.2",
     "fastify": "^5.8.2",
     "get-port": "^7.1.0",
     "prisma": "^7.8.0",

--- a/packages/server/scripts/ts_preload.js
+++ b/packages/server/scripts/ts_preload.js
@@ -15,9 +15,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import { register } from "node:module";
-import { pathToFileURL } from "node:url";
 
-register("ts-node/esm", pathToFileURL("./"));
+register("ts-node/esm", import.meta.url);
 
 process.on("uncaughtException", (err) => {
   console.error("Uncaught exception:", err);

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -1,17 +1,21 @@
-import { unstable_startServer } from "@prisma/dev";
+import { startPrismaDevServer } from "@prisma/dev";
 import { $ } from "execa";
 import getPort from "get-port";
 import path from "path";
 import { pathToFileURL } from "node:url";
+import { config } from "dotenv";
 
 if (process.env.NODE_ENV === "production") {
   throw new Error("Dev server should not be started in production mode");
 }
 
+config({ path: path.resolve(import.meta.dirname, "../.env") });
+process.env.NODE_USE_ENV_PROXY = "1";
+
 async function startLocalPrisma(name: string) {
   const port = await getPort();
 
-  return await unstable_startServer({
+  return await startPrismaDevServer({
     name,
     port,
     persistenceMode: "stateful",
@@ -23,7 +27,8 @@ async function startLocalPrisma(name: string) {
 
 const importFlags = [
   `--import`,
-  pathToFileURL(path.resolve(import.meta.dirname, "../scripts/ts_preload.js")).href,
+  pathToFileURL(path.resolve(import.meta.dirname, "../scripts/ts_preload.js"))
+    .href,
 ];
 
 async function localDev() {

--- a/packages/server/src/dev.ts
+++ b/packages/server/src/dev.ts
@@ -2,6 +2,7 @@ import { unstable_startServer } from "@prisma/dev";
 import { $ } from "execa";
 import getPort from "get-port";
 import path from "path";
+import { pathToFileURL } from "node:url";
 
 if (process.env.NODE_ENV === "production") {
   throw new Error("Dev server should not be started in production mode");
@@ -22,7 +23,7 @@ async function startLocalPrisma(name: string) {
 
 const importFlags = [
   `--import`,
-  path.resolve(import.meta.dirname, "../scripts/ts_preload.js"),
+  pathToFileURL(path.resolve(import.meta.dirname, "../scripts/ts_preload.js")).href,
 ];
 
 async function localDev() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,6 +528,9 @@ importers:
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       fastify:
         specifier: ^5.8.2
         version: 5.8.2
@@ -5140,8 +5143,8 @@ packages:
     resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
     engines: {node: 20 || >=22}
 
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+  glob@7.2.0:
+    resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
@@ -12775,7 +12778,7 @@ snapshots:
       minipass: 7.1.2
       path-scurry: 2.0.0
 
-  glob@7.2.3:
+  glob@7.2.0:
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -14133,7 +14136,7 @@ snapshots:
 
   rimraf@3.0.2:
     dependencies:
-      glob: 7.2.3
+      glob: 7.2.0
 
   rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(typescript@6.0.2):
     dependencies:


### PR DESCRIPTION
Explicitly use file URL for import.

Fix errors on importing absolute path on Windows caused unrecognized scheme "c:".