### PR TITLE
refactor(card-data-viewer): improve style and logic

### DIFF
--- a/packages/card-data-viewer/README.md
+++ b/packages/card-data-viewer/README.md
@@ -8,7 +8,8 @@ import { createCardDataViewer } from "@gi-tcg/card-data-viewer";
 const App = () => {
   const { CardDataViewer, showCharacter, showState, showCard, showSkill } =
     createCardDataViewer({
-      // includesImage: true,
+        // assetsManager?: Accessor<AssetsManager>;
+        // locale?: Accessor<Locale>;
     });
   onMount(() => {
     showState(
@@ -17,10 +18,11 @@ const App = () => {
       [
         /* combat status state data */
       ],
+      { includesImage: false },
     );
     showState("summon", { /* state data */ });
     showState("card", { /* state data */ });
-    showCard(212111);
+    showCard(212111, { includesImage: true });
     showCharacter(1610);
     showSkill(12111);
   });

--- a/packages/card-data-viewer/src/CardDataViewer.tsx
+++ b/packages/card-data-viewer/src/CardDataViewer.tsx
@@ -31,11 +31,10 @@ import { ActionCard, Character, Entity, Keyword, Skill } from "./Entity";
 import { useAssetsManager } from "./context";
 import { CardFace } from "./CardFace";
 
-export type StateType =
-  | AnyState["definition"]["type"]
-  | "card"
-  | "skill"
-  | "keyword";
+type MainStateType = "character" | "card" | "entity" | "skill" | "keyword";
+type SubStateType = "attachment" | "status" | "combatStatus" | "equipment";
+
+export type StateType = MainStateType | SubStateType;
 
 export type ViewerInput =
   | {
@@ -107,7 +106,7 @@ function CardDataViewer(props: CardDataViewerProps) {
             </div>
           )}
         </For>
-        <For each={grouped().card}>
+        <For each={[...(grouped().card ?? []), ...(grouped().entity ?? [])]}>
           {(input) => (
             <div class="card-panel">
               <ActionCard
@@ -123,18 +122,6 @@ function CardDataViewer(props: CardDataViewerProps) {
           {(input) => (
             <div class="card-panel">
               <Skill
-                class="min-h-0"
-                {...props}
-                input={input}
-                onRequestExplain={onRequestExplain}
-              />
-            </div>
-          )}
-        </For>
-        <For each={[...(grouped().summon ?? []), ...(grouped().support ?? [])]}>
-          {(input) => (
-            <div class="card-panel">
-              <Entity
                 class="min-h-0"
                 {...props}
                 input={input}

--- a/packages/card-data-viewer/src/CardDataViewer.tsx
+++ b/packages/card-data-viewer/src/CardDataViewer.tsx
@@ -33,7 +33,12 @@ import { useAssetsManager } from "./context";
 import { CardFace } from "./CardFace";
 
 type MainStateType = "character" | "card" | "entity" | "skill" | "keyword";
-type SubStateType = "attachment" | "status" | "combatStatus" | "equipment";
+type SubStateType =
+  | "equipment"
+  | "status"
+  | "equipAndStatus"
+  | "combatStatus"
+  | "attachment";
 
 export type StateType = MainStateType | SubStateType;
 
@@ -70,13 +75,28 @@ export function CardDataViewerContainer(props: CardDataViewerContainerProps) {
 
 function CardDataViewer(props: CardDataViewerProps) {
   const { t } = useAssetsManager();
-  const grouped = createMemo(() => Object.groupBy(props.inputs, (i) => i.type));
+  const [combineCharEntities, setCombineCharEntities] =
+    createSignal<boolean>(false);
+
+  const grouped = createMemo(() =>
+    Object.groupBy(props.inputs, (i) => {
+      if (
+        combineCharEntities() &&
+        (i.type === "equipment" || i.type === "status")
+      ) {
+        return "equipAndStatus";
+      } else {
+        return i.type;
+      }
+    }),
+  );
   const subEntities = () => {
     const render: (ViewerInput | SubStateType)[] = [];
     const g = grouped();
     for (const t of [
-      "equipment",      
+      "equipment",
       "status",
+      "equipAndStatus",
       "combatStatus",
       "attachment",
     ] as SubStateType[]) {
@@ -87,6 +107,12 @@ function CardDataViewer(props: CardDataViewerProps) {
     }
     return render;
   };
+
+  const showCombineButton = (type: SubStateType) =>
+    !!(
+      (grouped().equipment?.length && grouped().status?.length) ||
+      grouped().equipAndStatus?.length
+    ) && ["equipment", "status", "equipAndStatus"].includes(type);
 
   const [explainKeyword, setExplainKeyword] = createSignal<number | null>(null);
   const onRequestExplain = (definitionId: number | null) => {
@@ -131,30 +157,42 @@ function CardDataViewer(props: CardDataViewerProps) {
         </For>
         <Show when={subEntities()?.length}>
           <div class="card-panel">
-            <For each={subEntities()}>
-              {(entity) => (
-                <Switch>
-                  <Match when={typeof entity === "string"}>
-                    <h3 class="w-full text-center rounded-full entity-category">
-                      {t(entity as SubStateType)}
-                    </h3>
-                  </Match>
-                  <Match when={true}>
-                    <Entity
-                      input={entity as ViewerInput}
-                      asChild
-                      onRequestExplain={onRequestExplain}
-                    />
-                  </Match>
-                </Switch>
-              )}
-            </For>
+            <div class="flex flex-col gap-[0.5em]">
+              <For each={subEntities()}>
+                {(entity) => (
+                  <Switch>
+                    <Match when={typeof entity === "string"}>
+                      <h3
+                        class="w-full text-center rounded-full entity-category"
+                        bool:data-show-combine-button={showCombineButton(
+                          entity as SubStateType,
+                        )}
+                        onClick={() => {
+                          if (showCombineButton(entity as SubStateType)) {
+                            setCombineCharEntities((v) => !v);
+                          }
+                        }}
+                      >
+                        {t(entity as SubStateType)}
+                      </h3>
+                    </Match>
+                    <Match when={true}>
+                      <Entity
+                        input={entity as ViewerInput}
+                        asChild
+                        onRequestExplain={onRequestExplain}
+                      />
+                    </Match>
+                  </Switch>
+                )}
+              </For>
+            </div>
           </div>
         </Show>
         <Show when={explainKeyword()}>
           {(defId) => (
             <div class="card-panel">
-              <h3 class="w-full text-center rounded-full entity-category">
+              <h3 class="w-full text-center rounded-full mb-[0.5em] entity-category">
                 {t("rulesExplanation")}
               </h3>
               <Keyword {...props} definitionId={defId()} />

--- a/packages/card-data-viewer/src/CardDataViewer.tsx
+++ b/packages/card-data-viewer/src/CardDataViewer.tsx
@@ -29,6 +29,7 @@ import {
 } from "solid-js";
 import { ActionCard, Character, Entity, Keyword, Skill } from "./Entity";
 import { useAssetsManager } from "./context";
+import { CardFace } from "./CardFace";
 
 export type StateType =
   | AnyState["definition"]["type"]
@@ -52,7 +53,7 @@ export type ViewerInput =
 
 export interface CardDataViewerProps {
   inputs: ViewerInput[];
-  includesImage: boolean;
+  mainImageDefId: number | null;
 }
 
 export interface CardDataViewerContainerProps extends CardDataViewerProps {
@@ -92,6 +93,9 @@ function CardDataViewer(props: CardDataViewerProps) {
           </div>
         )}
       >
+        <Show when={props.mainImageDefId}>
+          {(id) => <CardFace defId={id()} />}
+        </Show>
         <For each={grouped().character}>
           {(input) => (
             <div class="card-panel">

--- a/packages/card-data-viewer/src/CardDataViewer.tsx
+++ b/packages/card-data-viewer/src/CardDataViewer.tsx
@@ -13,7 +13,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import type { AnyState } from "@gi-tcg/core";
 import type {
   PbAttachmentState,
   PbCharacterState,
@@ -25,7 +24,9 @@ import {
   createSignal,
   ErrorBoundary,
   For,
+  Match,
   Show,
+  Switch,
 } from "solid-js";
 import { ActionCard, Character, Entity, Keyword, Skill } from "./Entity";
 import { useAssetsManager } from "./context";
@@ -70,9 +71,21 @@ export function CardDataViewerContainer(props: CardDataViewerContainerProps) {
 function CardDataViewer(props: CardDataViewerProps) {
   const { t } = useAssetsManager();
   const grouped = createMemo(() => Object.groupBy(props.inputs, (i) => i.type));
-  const hasStatuses = () => {
+  const subEntities = () => {
+    const render: (ViewerInput | SubStateType)[] = [];
     const g = grouped();
-    return g.equipment || g.status || g.combatStatus || g.attachment;
+    for (const t of [
+      "attachment",
+      "status",
+      "combatStatus",
+      "equipment",
+    ] as SubStateType[]) {
+      if (g[t]?.length) {
+        render.push(t);
+        render.push(...g[t]);
+      }
+    }
+    return render;
   };
 
   const [explainKeyword, setExplainKeyword] = createSignal<number | null>(null);
@@ -98,11 +111,7 @@ function CardDataViewer(props: CardDataViewerProps) {
         <For each={grouped().character}>
           {(input) => (
             <div class="card-panel">
-              <Character
-                {...props}
-                input={input}
-                onRequestExplain={onRequestExplain}
-              />
+              <Character input={input} onRequestExplain={onRequestExplain} />
             </div>
           )}
         </For>
@@ -110,8 +119,6 @@ function CardDataViewer(props: CardDataViewerProps) {
           {(input) => (
             <div class="card-panel">
               <ActionCard
-                class="min-h-0"
-                {...props}
                 input={input}
                 onRequestExplain={onRequestExplain}
               />
@@ -122,70 +129,30 @@ function CardDataViewer(props: CardDataViewerProps) {
           {(input) => (
             <div class="card-panel">
               <Skill
-                class="min-h-0"
-                {...props}
                 input={input}
                 onRequestExplain={onRequestExplain}
               />
             </div>
           )}
         </For>
-        <Show when={hasStatuses()}>
+        <Show when={subEntities()?.length}>
           <div class="card-panel">
-            <Show when={grouped().equipment?.length}>
-              <h3 class="text-yellow-7 mb-2">{t("equipment")}</h3>
-            </Show>
-            <For each={grouped().equipment}>
-              {(input) => (
-                <Entity
-                  class="b-yellow-3 b-1 rounded-md mb-2"
-                  {...props}
-                  input={input}
-                  asChild
-                  onRequestExplain={onRequestExplain}
-                />
-              )}
-            </For>
-            <Show when={grouped().status?.length}>
-              <h3 class="text-yellow-7 mb-2">{t("status")}</h3>
-            </Show>
-            <For each={grouped().status}>
-              {(input) => (
-                <Entity
-                  class="b-yellow-3 b-1 rounded-md mb-2"
-                  {...props}
-                  input={input}
-                  asChild
-                  onRequestExplain={onRequestExplain}
-                />
-              )}
-            </For>
-            <Show when={grouped().combatStatus?.length}>
-              <h3 class="text-yellow-7 mb-2">{t("combatStatus")}</h3>
-            </Show>
-            <For each={grouped().combatStatus}>
-              {(input) => (
-                <Entity
-                  class="b-yellow-3 b-1 rounded-md mb-2"
-                  {...props}
-                  input={input}
-                  asChild
-                  onRequestExplain={onRequestExplain}
-                />
-              )}
-            </For>
-            <Show when={grouped().attachment?.length}>
-              <h3 class="text-yellow-7 mb-2">{t("attachmentStatus")}</h3>
-            </Show>
-            <For each={grouped().attachment}>
-              {(input) => (
-                <Entity
-                  class="b-yellow-3 b-1 rounded-md mb-2"
-                  {...props}
-                  input={input}
-                  asChild
-                  onRequestExplain={onRequestExplain}
-                />
+            <For each={subEntities()}>
+              {(entity) => (
+                <Switch>
+                  <Match when={typeof entity === "string"}>
+                    <h3 class="w-full text-center rounded-full entity-category">
+                      {t(entity as SubStateType)}
+                    </h3>
+                  </Match>
+                  <Match when={true}>
+                    <Entity
+                      input={entity as ViewerInput}
+                      asChild
+                      onRequestExplain={onRequestExplain}
+                    />
+                  </Match>
+                </Switch>
               )}
             </For>
           </div>

--- a/packages/card-data-viewer/src/CardDataViewer.tsx
+++ b/packages/card-data-viewer/src/CardDataViewer.tsx
@@ -75,10 +75,10 @@ function CardDataViewer(props: CardDataViewerProps) {
     const render: (ViewerInput | SubStateType)[] = [];
     const g = grouped();
     for (const t of [
-      "attachment",
+      "equipment",      
       "status",
       "combatStatus",
-      "equipment",
+      "attachment",
     ] as SubStateType[]) {
       if (g[t]?.length) {
         render.push(t);
@@ -89,7 +89,7 @@ function CardDataViewer(props: CardDataViewerProps) {
   };
 
   const [explainKeyword, setExplainKeyword] = createSignal<number | null>(null);
-  const onRequestExplain = (definitionId: number) => {
+  const onRequestExplain = (definitionId: number | null) => {
     setExplainKeyword((prev) => (prev === definitionId ? null : definitionId));
   };
 
@@ -118,20 +118,14 @@ function CardDataViewer(props: CardDataViewerProps) {
         <For each={[...(grouped().card ?? []), ...(grouped().entity ?? [])]}>
           {(input) => (
             <div class="card-panel">
-              <ActionCard
-                input={input}
-                onRequestExplain={onRequestExplain}
-              />
+              <ActionCard input={input} onRequestExplain={onRequestExplain} />
             </div>
           )}
         </For>
         <For each={grouped().skill}>
           {(input) => (
             <div class="card-panel">
-              <Skill
-                input={input}
-                onRequestExplain={onRequestExplain}
-              />
+              <Skill input={input} onRequestExplain={onRequestExplain} />
             </div>
           )}
         </For>
@@ -160,13 +154,10 @@ function CardDataViewer(props: CardDataViewerProps) {
         <Show when={explainKeyword()}>
           {(defId) => (
             <div class="card-panel">
+              <h3 class="w-full text-center rounded-full entity-category">
+                {t("rulesExplanation")}
+              </h3>
               <Keyword {...props} definitionId={defId()} />
-              <div
-                class="absolute right-1 top-1 text-xs"
-                onClick={() => setExplainKeyword(null)}
-              >
-                &#10060;
-              </div>
             </div>
           )}
         </Show>

--- a/packages/card-data-viewer/src/CardDataViewer.tsx
+++ b/packages/card-data-viewer/src/CardDataViewer.tsx
@@ -14,6 +14,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import type { AnyState } from "@gi-tcg/core";
+import type {
+  PbAttachmentState,
+  PbCharacterState,
+  PbEntityState,
+} from "@gi-tcg/typings";
 import {
   createEffect,
   createMemo,
@@ -42,10 +47,7 @@ export type ViewerInput =
       id: number;
       type: StateType;
       definitionId: number;
-      variableValue?: number;
-      descriptionDictionary: {
-        [key: string]: string;
-      };
+      state: PbCharacterState | PbEntityState | PbAttachmentState;
     };
 
 export interface CardDataViewerProps {
@@ -90,130 +92,126 @@ function CardDataViewer(props: CardDataViewerProps) {
           </div>
         )}
       >
-        <div class="h-full w-full flex flex-row justify-begin items-start select-none gap-2 min-h-0">
-          <For each={grouped().character}>
-            {(input) => (
-              <div class="card-panel">
-                <Character
-                  {...props}
-                  input={input}
-                  onRequestExplain={onRequestExplain}
-                />
-              </div>
-            )}
-          </For>
-          <For each={grouped().card}>
-            {(input) => (
-              <div class="card-panel">
-                <ActionCard
-                  class="min-h-0"
-                  {...props}
-                  input={input}
-                  onRequestExplain={onRequestExplain}
-                />
-              </div>
-            )}
-          </For>
-          <For each={grouped().skill}>
-            {(input) => (
-              <div class="card-panel">
-                <Skill
-                  class="min-h-0"
-                  {...props}
-                  input={input}
-                  onRequestExplain={onRequestExplain}
-                />
-              </div>
-            )}
-          </For>
-          <For
-            each={[...(grouped().summon ?? []), ...(grouped().support ?? [])]}
-          >
-            {(input) => (
-              <div class="card-panel">
-                <Entity
-                  class="min-h-0"
-                  {...props}
-                  input={input}
-                  onRequestExplain={onRequestExplain}
-                />
-              </div>
-            )}
-          </For>
-          <Show when={hasStatuses()}>
+        <For each={grouped().character}>
+          {(input) => (
             <div class="card-panel">
-              <Show when={grouped().equipment?.length}>
-                <h3 class="text-yellow-7 mb-2">{t("equipment")}</h3>
-              </Show>
-              <For each={grouped().equipment}>
-                {(input) => (
-                  <Entity
-                    class="b-yellow-3 b-1 rounded-md mb-2"
-                    {...props}
-                    input={input}
-                    asChild
-                    onRequestExplain={onRequestExplain}
-                  />
-                )}
-              </For>
-              <Show when={grouped().status?.length}>
-                <h3 class="text-yellow-7 mb-2">{t("status")}</h3>
-              </Show>
-              <For each={grouped().status}>
-                {(input) => (
-                  <Entity
-                    class="b-yellow-3 b-1 rounded-md mb-2"
-                    {...props}
-                    input={input}
-                    asChild
-                    onRequestExplain={onRequestExplain}
-                  />
-                )}
-              </For>
-              <Show when={grouped().combatStatus?.length}>
-                <h3 class="text-yellow-7 mb-2">{t("combatStatus")}</h3>
-              </Show>
-              <For each={grouped().combatStatus}>
-                {(input) => (
-                  <Entity
-                    class="b-yellow-3 b-1 rounded-md mb-2"
-                    {...props}
-                    input={input}
-                    asChild
-                    onRequestExplain={onRequestExplain}
-                  />
-                )}
-              </For>
-              <Show when={grouped().attachment?.length}>
-                <h3 class="text-yellow-7 mb-2">{t("attachmentStatus")}</h3>
-              </Show>
-              <For each={grouped().attachment}>
-                {(input) => (
-                  <Entity
-                    class="b-yellow-3 b-1 rounded-md mb-2"
-                    {...props}
-                    input={input}
-                    asChild
-                    onRequestExplain={onRequestExplain}
-                  />
-                )}
-              </For>
+              <Character
+                {...props}
+                input={input}
+                onRequestExplain={onRequestExplain}
+              />
             </div>
-          </Show>
-          <Show when={explainKeyword()}>
-            {(defId) => (
-              <div class="card-panel">
-                <Keyword {...props} definitionId={defId()} />
-                <div
-                  class="absolute right-1 top-1 text-xs"
-                  onClick={() => setExplainKeyword(null)}
-                >
-                  &#10060;
-                </div>
+          )}
+        </For>
+        <For each={grouped().card}>
+          {(input) => (
+            <div class="card-panel">
+              <ActionCard
+                class="min-h-0"
+                {...props}
+                input={input}
+                onRequestExplain={onRequestExplain}
+              />
+            </div>
+          )}
+        </For>
+        <For each={grouped().skill}>
+          {(input) => (
+            <div class="card-panel">
+              <Skill
+                class="min-h-0"
+                {...props}
+                input={input}
+                onRequestExplain={onRequestExplain}
+              />
+            </div>
+          )}
+        </For>
+        <For each={[...(grouped().summon ?? []), ...(grouped().support ?? [])]}>
+          {(input) => (
+            <div class="card-panel">
+              <Entity
+                class="min-h-0"
+                {...props}
+                input={input}
+                onRequestExplain={onRequestExplain}
+              />
+            </div>
+          )}
+        </For>
+        <Show when={hasStatuses()}>
+          <div class="card-panel">
+            <Show when={grouped().equipment?.length}>
+              <h3 class="text-yellow-7 mb-2">{t("equipment")}</h3>
+            </Show>
+            <For each={grouped().equipment}>
+              {(input) => (
+                <Entity
+                  class="b-yellow-3 b-1 rounded-md mb-2"
+                  {...props}
+                  input={input}
+                  asChild
+                  onRequestExplain={onRequestExplain}
+                />
+              )}
+            </For>
+            <Show when={grouped().status?.length}>
+              <h3 class="text-yellow-7 mb-2">{t("status")}</h3>
+            </Show>
+            <For each={grouped().status}>
+              {(input) => (
+                <Entity
+                  class="b-yellow-3 b-1 rounded-md mb-2"
+                  {...props}
+                  input={input}
+                  asChild
+                  onRequestExplain={onRequestExplain}
+                />
+              )}
+            </For>
+            <Show when={grouped().combatStatus?.length}>
+              <h3 class="text-yellow-7 mb-2">{t("combatStatus")}</h3>
+            </Show>
+            <For each={grouped().combatStatus}>
+              {(input) => (
+                <Entity
+                  class="b-yellow-3 b-1 rounded-md mb-2"
+                  {...props}
+                  input={input}
+                  asChild
+                  onRequestExplain={onRequestExplain}
+                />
+              )}
+            </For>
+            <Show when={grouped().attachment?.length}>
+              <h3 class="text-yellow-7 mb-2">{t("attachmentStatus")}</h3>
+            </Show>
+            <For each={grouped().attachment}>
+              {(input) => (
+                <Entity
+                  class="b-yellow-3 b-1 rounded-md mb-2"
+                  {...props}
+                  input={input}
+                  asChild
+                  onRequestExplain={onRequestExplain}
+                />
+              )}
+            </For>
+          </div>
+        </Show>
+        <Show when={explainKeyword()}>
+          {(defId) => (
+            <div class="card-panel">
+              <Keyword {...props} definitionId={defId()} />
+              <div
+                class="absolute right-1 top-1 text-xs"
+                onClick={() => setExplainKeyword(null)}
+              >
+                &#10060;
               </div>
-            )}
-          </Show>
-        </div>
+            </div>
+          )}
+        </Show>
       </ErrorBoundary>
     </div>
   );

--- a/packages/card-data-viewer/src/CardDataViewer.tsx
+++ b/packages/card-data-viewer/src/CardDataViewer.tsx
@@ -78,18 +78,19 @@ function CardDataViewer(props: CardDataViewerProps) {
   const [combineCharEntities, setCombineCharEntities] =
     createSignal<boolean>(false);
 
-  const grouped = createMemo(() =>
-    Object.groupBy(props.inputs, (i) => {
+  const grouped = createMemo(() => {
+    const combineEquipAndStatus = combineCharEntities();
+    return Object.groupBy(props.inputs, (i) => {
       if (
-        combineCharEntities() &&
+        combineEquipAndStatus &&
         (i.type === "equipment" || i.type === "status")
       ) {
         return "equipAndStatus";
       } else {
         return i.type;
       }
-    }),
-  );
+    });
+  });
   const subEntities = () => {
     const render: (ViewerInput | SubStateType)[] = [];
     const g = grouped();
@@ -161,20 +162,22 @@ function CardDataViewer(props: CardDataViewerProps) {
               <For each={subEntities()}>
                 {(entity) => (
                   <Switch>
-                    <Match when={typeof entity === "string"}>
-                      <h3
-                        class="w-full text-center rounded-full entity-category"
-                        bool:data-show-combine-button={showCombineButton(
-                          entity as SubStateType,
-                        )}
-                        onClick={() => {
-                          if (showCombineButton(entity as SubStateType)) {
-                            setCombineCharEntities((v) => !v);
-                          }
-                        }}
-                      >
-                        {t(entity as SubStateType)}
-                      </h3>
+                    <Match when={typeof entity === "string" && entity}>
+                      {(entityType) => (
+                        <h3
+                          class="w-full text-center rounded-full entity-category"
+                          bool:data-show-combine-button={showCombineButton(
+                            entityType(),
+                          )}
+                          onClick={() => {
+                            if (showCombineButton(entityType())) {
+                              setCombineCharEntities((v) => !v);
+                            }
+                          }}
+                        >
+                          {t(entityType())}
+                        </h3>
+                      )}
                     </Match>
                     <Match when={true}>
                       <Entity

--- a/packages/card-data-viewer/src/CardFace.tsx
+++ b/packages/card-data-viewer/src/CardFace.tsx
@@ -31,7 +31,7 @@ export function CardFace(props: CardFaceProps) {
   const frameUrl = `${UI_ASSET_URL_BASE}CardFrameNormal.svg.webp`;
   return (
     <div class="grid children:grid-area-[1/1] card-face">
-      <Show when={image()} fallback={<div class="w-full h-full bg-black/50" />}>
+      <Show when={image()} fallback={<div class="w-full h-full bg-black/50 rounded-[1em]" />}>
         {(image) => <img src={image()} class="w-full h-full" />}
       </Show>
       <img src={frameUrl} class="w-full h-full" />

--- a/packages/card-data-viewer/src/CardFace.tsx
+++ b/packages/card-data-viewer/src/CardFace.tsx
@@ -1,0 +1,40 @@
+// Copyright (C) 2026 Piovium Labs
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import { createResource, Show } from "solid-js";
+import { useAssetsManager } from "./context";
+
+export const UI_ASSET_URL_BASE = "https://ui-assets.piovium.org/";
+
+export interface CardFaceProps {
+  defId: number;
+}
+
+export function CardFace(props: CardFaceProps) {
+  const { assetsManager } = useAssetsManager();
+  const [image] = createResource(
+    () => [props.defId, assetsManager()] as const,
+    ([defId, manager]) => manager.getImageUrl(defId),
+  );
+  const frameUrl = `${UI_ASSET_URL_BASE}CardFrameNormal.svg.webp`;
+  return (
+    <div class="grid children:grid-area-[1/1] card-face">
+      <Show when={image()} fallback={<div class="w-full h-full bg-black/50" />}>
+        {(image) => <img src={image()} class="w-full h-full" />}
+      </Show>
+      <img src={frameUrl} class="w-full h-full" />
+    </div>
+  );
+}

--- a/packages/card-data-viewer/src/Description.tsx
+++ b/packages/card-data-viewer/src/Description.tsx
@@ -132,7 +132,6 @@ export interface DescriptionProps {
   definitionId: number;
   description: string;
   keyMap?: Record<string, string>;
-  includesImage: boolean;
   fromSkill?: boolean;
   onRequestExplain?: (id: number) => void;
   onAddReference?: (defId: number) => void;

--- a/packages/card-data-viewer/src/Description.tsx
+++ b/packages/card-data-viewer/src/Description.tsx
@@ -83,14 +83,14 @@ interface DamageDescriptionProps {
 }
 
 const DAMAGE_COLORS = [
-  "#000000",
-  "#91d5ff",
-  "#1890ff",
-  "#f5222d",
-  "#722ed1",
-  "#36cfc9",
-  "#d4b106",
-  "#52c41a",
+  "",
+  "#63d4e2",
+  "#5791e0",
+  "#f07648",
+  "#b178eb",
+  "#52daab",
+  "#e2a60b",
+  "#9bca13",
 ];
 
 function DamageDescription(props: DamageDescriptionProps) {
@@ -115,10 +115,10 @@ function DamageDescription(props: DamageDescriptionProps) {
   return (
     <>
       <Show when={id() <= 7 && url()}>
-        {(url) => <img src={url()} class="inline-block h-1em mb-2px mx-1" />}
+        {(url) => <img src={url()} class="inline-block h-[1.25em]" />}
       </Show>
       <span
-        class="underline underline-1 underline-offset-3 cursor-pointer"
+        class="cursor-pointer description-underline"
         style={{ color: DAMAGE_COLORS[id()] }}
         onClick={() => props.onRequestExplain?.(keywordId())}
       >
@@ -139,7 +139,6 @@ export interface DescriptionProps {
 }
 
 export function Description(props: DescriptionProps) {
-  const { assetsManager } = useAssetsManager();
   const items = createMemo(() =>
     descriptionToItems(props.description, props.keyMap),
   );
@@ -170,7 +169,7 @@ export function Description(props: DescriptionProps) {
 
   return (
     <>
-      <p class="line-height-normal whitespace-pre-wrap mb-2">
+      <p class="line-height-normal whitespace-pre-wrap mb-2 description">
         <For each={items()}>
           {(item) => (
             <Switch>
@@ -193,13 +192,13 @@ export function Description(props: DescriptionProps) {
                   <Show
                     when={item.rType === "K"}
                     fallback={
-                      <span class="text-black mx-1">
+                      <span class="description-strong">
                         <ReferenceName definitionId={item.id} />
                       </span>
                     }
                   >
                     <span
-                      class="text-black underline underline-1 underline-offset-3 cursor-pointer mx-1"
+                      class="description-underline cursor-pointer"
                       onClick={() => props.onRequestExplain?.(item.id)}
                     >
                       <ReferenceName definitionId={item.id} />
@@ -214,7 +213,7 @@ export function Description(props: DescriptionProps) {
       <ul>
         <For each={references}>
           {(defId) => (
-            <li class="b-l-2 p-l-2 b-solid b-yellow-5 mb-2">
+            <li class="keyword">
               <Reference
                 {...props}
                 definitionId={defId}

--- a/packages/card-data-viewer/src/Description.tsx
+++ b/packages/card-data-viewer/src/Description.tsx
@@ -120,7 +120,10 @@ function DamageDescription(props: DamageDescriptionProps) {
       <span
         class="cursor-pointer description-underline"
         style={{ color: DAMAGE_COLORS[id()] }}
-        onClick={() => props.onRequestExplain?.(keywordId())}
+        onClick={(e) => {
+          e.stopPropagation();
+          props.onRequestExplain?.(keywordId());
+        }}
       >
         <ReferenceName definitionId={keywordId()} />
       </span>
@@ -133,7 +136,7 @@ export interface DescriptionProps {
   description: string;
   keyMap?: Record<string, string>;
   fromSkill?: boolean;
-  onRequestExplain?: (id: number) => void;
+  onRequestExplain?: (id: number | null) => void;
   onAddReference?: (defId: number) => void;
 }
 
@@ -168,7 +171,10 @@ export function Description(props: DescriptionProps) {
 
   return (
     <>
-      <p class="line-height-normal whitespace-pre-wrap mb-2 description">
+      <p
+        class="line-height-normal whitespace-pre-wrap mb-2 description"
+        onClick={() => props.onRequestExplain?.(null)}
+      >
         <For each={items()}>
           {(item) => (
             <Switch>
@@ -198,7 +204,10 @@ export function Description(props: DescriptionProps) {
                   >
                     <span
                       class="description-underline cursor-pointer"
-                      onClick={() => props.onRequestExplain?.(item.id)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        props.onRequestExplain?.(item.id);
+                      }}
                     >
                       <ReferenceName definitionId={item.id} />
                     </span>
@@ -212,7 +221,7 @@ export function Description(props: DescriptionProps) {
       <ul>
         <For each={references}>
           {(defId) => (
-            <li class="keyword">
+            <li class="reference">
               <Reference
                 {...props}
                 definitionId={defId}

--- a/packages/card-data-viewer/src/Entity.tsx
+++ b/packages/card-data-viewer/src/Entity.tsx
@@ -59,12 +59,22 @@ export function Character(props: CardDataProps) {
     () => [props.input.definitionId, assetsManager()] as const,
     ([defId, manager]) => manager.getData(defId) as Promise<CharacterRawData>,
   );
-  const hpText = () =>
-    state() ? `${state()!.health}/${state()!.maxHealth}` : `${data()!.hp}`;
-  const mpText = () =>
-    state()
-      ? `${state()!.energy}/${state()!.maxEnergy}`
-      : `${data()!.maxEnergy}`;
+  const hpText = createMemo(() => {
+    const st = state();
+    if (st) {
+      return `${st.health}/${st.maxHealth}`;
+    } else {
+      return data()?.hp ?? 0;
+    }
+  });
+  const mpText = createMemo(() => {
+    const st = state();
+    if (st) {
+      return `${st.energy}/${st.maxEnergy}`;
+    } else {
+      return data()?.maxEnergy ?? 0;
+    }
+  });
   return (
     <div class={props.class}>
       <Switch>
@@ -102,10 +112,7 @@ export function Character(props: CardDataProps) {
           )}
         </Match>
       </Switch>
-      <IdBox
-        defId={props.input.definitionId}
-        id={state() ? state()!.id : void 0}
-      />
+      <IdBox defId={props.input.definitionId} id={state()?.id} />
     </div>
   );
 }
@@ -124,22 +131,18 @@ export function ActionCard(props: CardDataProps) {
     ([defId, manager]) =>
       manager.getData(defId) as Promise<ActionCardRawData | EntityRawData>,
   );
-  const rawDescription = () => {
-    if (state()) {
-      if (
-        props.input.type === "card" &&
-        (data() as ActionCardRawData).rawDynamicDescription
-      ) {
-        return (data() as ActionCardRawData).rawDynamicDescription;
-      } else if (
-        props.input.type === "entity" &&
-        data()!.rawPlayingDescription
-      ) {
-        return data()!.rawPlayingDescription;
+  const rawDescription = createMemo(() => {
+    const st = state();
+    const d = data() as ActionCardRawData | undefined;
+    if (st) {
+      if (props.input.type === "card" && d?.rawDynamicDescription) {
+        return d.rawDynamicDescription;
+      } else if (props.input.type === "entity" && d?.rawPlayingDescription) {
+        return d.rawPlayingDescription;
       }
     }
-    return data()!.rawDescription;
-  };
+    return d?.rawDescription;
+  });
   return (
     <div class={props.class}>
       <Switch>
@@ -163,9 +166,9 @@ export function ActionCard(props: CardDataProps) {
               <div class="px-[0.5em]">
                 <Description
                   {...props}
-                  keyMap={state() ? state()!.descriptionDictionary : {}}
+                  keyMap={state()?.descriptionDictionary ?? {}}
                   definitionId={props.input.definitionId}
-                  description={rawDescription()!}
+                  description={rawDescription() ?? ""}
                   onRequestExplain={props.onRequestExplain}
                 />
               </div>
@@ -173,10 +176,7 @@ export function ActionCard(props: CardDataProps) {
           )}
         </Match>
       </Switch>
-      <IdBox
-        defId={props.input.definitionId}
-        id={state() ? state()!.id : void 0}
-      />
+      <IdBox defId={props.input.definitionId} id={state()?.id} />
     </div>
   );
 }
@@ -216,7 +216,7 @@ export function Skill(props: ExpandableCardDataProps) {
           {(icon) => (
             <div
               class="skill-icon shrink-0"
-              style={{ "mask-image": `url(${icon()})` }}
+              style={{ "--mask-image": `url(${icon()})` }}
             />
           )}
         </Show>
@@ -290,11 +290,7 @@ export function Entity(props: ExpandableCardDataProps) {
           <Show when={icon()}>
             {(icon) => <img src={icon()} class="w-[3em] h-[3em]" />}
           </Show>
-          <Show
-            when={
-              state() !== null && typeof state()!.variableValue === "number"
-            }
-          >
+          <Show when={typeof state()?.variableValue === "number"}>
             <div class="place-self-end rounded-full entity-variable">
               {state()!.variableValue}
             </div>
@@ -317,7 +313,7 @@ export function Entity(props: ExpandableCardDataProps) {
             {(data) => (
               <Description
                 {...props}
-                keyMap={state() ? state()!.descriptionDictionary : {}}
+                keyMap={state()?.descriptionDictionary ?? {}}
                 definitionId={props.input.definitionId}
                 description={
                   data().rawPlayingDescription ?? data().rawDescription
@@ -327,10 +323,7 @@ export function Entity(props: ExpandableCardDataProps) {
             )}
           </Match>
         </Switch>
-        <IdBox
-          defId={props.input.definitionId}
-          id={state() ? state()!.id : void 0}
-        />
+        <IdBox defId={props.input.definitionId} id={state()?.id} />
       </div>
     </details>
   );

--- a/packages/card-data-viewer/src/Entity.tsx
+++ b/packages/card-data-viewer/src/Entity.tsx
@@ -18,17 +18,12 @@ import {
   createMemo,
   createResource,
   createSignal,
-  createUniqueId,
   For,
   Match,
   Show,
   Switch,
 } from "solid-js";
-import type {
-  PbAttachmentState,
-  PbCharacterState,
-  PbEntityState,
-} from "@gi-tcg/typings";
+import type { PbCharacterState, PbEntityState } from "@gi-tcg/typings";
 import type { ViewerInput } from "./CardDataViewer";
 import type {
   ActionCardRawData,
@@ -213,7 +208,7 @@ export function Skill(props: ExpandableCardDataProps) {
   });
   return (
     <details
-      class={`flex flex-col skill-wrap group ${props.class ?? ""}`}
+      class={`flex flex-col min-h-0 skill-wrap group ${props.class ?? ""}`}
       open={!props.asChild}
     >
       <summary class="flex flex-row items-center p-[0.25em] gap-[0.25em] cursor-pointer skill-header">
@@ -233,7 +228,9 @@ export function Skill(props: ExpandableCardDataProps) {
           </h3>
           <div class="flex flex-row items-center">
             <span class="skill-type mr-[0.5em]">{skillTypeText()}</span>
-            <PlayCostList playCost={playCost()} />
+            <Show when={data()?.type !== "GCG_SKILL_TAG_PASSIVE"}>
+              <PlayCostList playCost={playCost()} />
+            </Show>
           </div>
         </div>
       </summary>
@@ -285,7 +282,7 @@ export function Entity(props: ExpandableCardDataProps) {
   });
   return (
     <details
-      class={`flex flex-col skill-wrap group ${props.class ?? ""}`}
+      class={`flex flex-col min-h-0 skill-wrap group ${props.class ?? ""}`}
       open={!props.asChild}
     >
       <summary class="flex flex-row items-center p-[0.25em] gap-[0.25em] cursor-pointer skill-header">

--- a/packages/card-data-viewer/src/Entity.tsx
+++ b/packages/card-data-viewer/src/Entity.tsx
@@ -15,13 +15,20 @@
 
 import {
   createEffect,
+  createMemo,
   createResource,
   createSignal,
+  createUniqueId,
   For,
   Match,
   Show,
   Switch,
 } from "solid-js";
+import type {
+  PbAttachmentState,
+  PbCharacterState,
+  PbEntityState,
+} from "@gi-tcg/typings";
 import type { ViewerInput } from "./CardDataViewer";
 import type {
   ActionCardRawData,
@@ -36,6 +43,7 @@ import { Description } from "./Description";
 import { Tags } from "./Tags";
 import { typeTagText } from "./text_map";
 import { useAssetsManager } from "./context";
+import { IdBox } from "./IdBox";
 
 export interface CardDataProps {
   class?: string;
@@ -45,6 +53,13 @@ export interface CardDataProps {
 }
 
 export function Character(props: CardDataProps) {
+  const state = createMemo(() => {
+    if (props.input.from === "definitionId") {
+      return null;
+    } else {
+      return props.input.state as PbCharacterState;
+    }
+  });
   const { assetsManager, t } = useAssetsManager();
   const [data] = createResource(
     () => [props.input.definitionId, assetsManager()] as const,
@@ -54,6 +69,12 @@ export function Character(props: CardDataProps) {
     () => [props.input.definitionId, assetsManager()] as const,
     ([defId, manager]) => manager.getImageUrl(defId, { type: "icon" }),
   );
+  const hpText = () =>
+    state() ? `${state()!.health}/${state()!.maxHealth}` : `${data()!.hp}`;
+  const mpText = () =>
+    state()
+      ? `${state()!.energy}/${state()!.maxEnergy}`
+      : `${data()!.maxEnergy}`;
   return (
     <div class={props.class}>
       <Switch>
@@ -63,21 +84,21 @@ export function Character(props: CardDataProps) {
           {(data) => (
             <>
               <Show when={props.includesImage}>
-                <div class="w-15 float-start mr-3 mb-3">
+                <div class="w-[3.75em] h-[3.75em] float-start mr-[0.5em] mb-[0.5em]">
                   <Show when={image()}>
-                    {(image) => <img src={image()} class="w-full" />}
+                    {(image) => <img src={image()} class="w-full h-full" />}
                   </Show>
                 </div>
               </Show>
-              <h3 class="font-bold mb-1">{data().name}</h3>
-              <dl class="flex flex-row gap-1 mb-1 text-sm">
+              <h3 class="card-name">{data().name}</h3>
+              <dl class="flex flex-row gap-[0.25em] mb-[0.25em] card-info">
                 <dt>HP</dt>
-                <dd class="font-bold">{data().hp}</dd>
+                <dd class="font-bold">{hpText()}</dd>
                 <dt>&nbsp;&nbsp;&nbsp;MP</dt>
-                <dd class="font-bold">{data().maxEnergy}</dd>
+                <dd class="font-bold">{mpText()}</dd>
               </dl>
               <Tags tags={data().tags} />
-              <ul class="clear-both flex flex-col gap-2">
+              <ul class="clear-both flex flex-col gap-[0.5em]">
                 <For each={data().skills}>
                   {(skill) => (
                     <Show when={!skill.hidden}>
@@ -89,7 +110,6 @@ export function Character(props: CardDataProps) {
                           definitionId: skill.id,
                         }}
                         asChild
-                        class="b-yellow-3 b-1 rounded-md"
                       />
                     </Show>
                   )}
@@ -99,22 +119,22 @@ export function Character(props: CardDataProps) {
           )}
         </Match>
       </Switch>
-      <p class="mt-2 text-xs font-mono text-yellow-6">
-        DefID: <span class="select-text">{props.input.definitionId}</span>
-        <Show when={props.input.from === "state" && props.input} keyed>
-          {(input) => (
-            <>
-              <span class="inline-block w-1em" />
-              ID: <span class="select-text">{input.id}</span>
-            </>
-          )}
-        </Show>
-      </p>
+      <IdBox
+        defId={props.input.definitionId}
+        id={state() ? state()!.id : void 0}
+      />
     </div>
   );
 }
 
 export function ActionCard(props: CardDataProps) {
+  const state = createMemo(() => {
+    if (props.input.from === "definitionId") {
+      return null;
+    } else {
+      return props.input.state as PbEntityState;
+    }
+  });
   const { assetsManager, t } = useAssetsManager();
   const [data] = createResource(
     () => [props.input.definitionId, assetsManager()] as const,
@@ -133,16 +153,18 @@ export function ActionCard(props: CardDataProps) {
           {(data) => (
             <>
               <Show when={props.includesImage}>
-                <div class="w-19 float-start mr-2 mb-0">
+                <div class="w-[4em] float-start mr-2">
                   <Show when={image()}>
                     {(image) => <img src={image()} class="w-full" />}
                   </Show>
                 </div>
               </Show>
-              <div class="flex flex-col mb-2">
-                <h3 class="font-bold">{data().name}</h3>
-                <div class="h-6 flex flex-row items-center gap-1">
-                  <span class="text-xs">{typeTagText(data().type, t)}</span>
+              <div class="flex flex-col mb-[0.25em]">
+                <h3 class="card-name">{data().name}</h3>
+                <div class="flex flex-row items-center">
+                  <span class="skill-type mr-[0.5em]">
+                    {typeTagText(data().type, t)}
+                  </span>
                   <PlayCostList playCost={data().playCost} />
                 </div>
               </div>
@@ -150,11 +172,7 @@ export function ActionCard(props: CardDataProps) {
               <div>
                 <Description
                   {...props}
-                  keyMap={
-                    props.input.from === "state"
-                      ? props.input.descriptionDictionary
-                      : {}
-                  }
+                  keyMap={state() ? state()!.descriptionDictionary : {}}
                   definitionId={props.input.definitionId}
                   description={
                     (props.input.from === "state" &&
@@ -168,17 +186,10 @@ export function ActionCard(props: CardDataProps) {
           )}
         </Match>
       </Switch>
-      <p class="mt-2 text-xs font-mono text-yellow-6">
-        DefID: <span class="select-text">{props.input.definitionId}</span>
-        <Show when={props.input.from === "state" && props.input} keyed>
-          {(input) => (
-            <>
-              <span class="inline-block w-1em" />
-              ID: <span class="select-text">{input.id}</span>
-            </>
-          )}
-        </Show>
-      </p>
+      <IdBox
+        defId={props.input.definitionId}
+        id={state() ? state()!.id : void 0}
+      />
     </div>
   );
 }
@@ -210,33 +221,36 @@ export function Skill(props: ExpandableCardDataProps) {
   });
   return (
     <details
-      class={`flex flex-col group ${props.class ?? ""}`}
+      class={`flex flex-col skill-wrap group ${props.class ?? ""}`}
       open={!props.asChild}
     >
-      <summary class="flex flex-row items-center gap-2 cursor-pointer rounded-md group-not-open:bg-yellow-2 transition-colors">
-        <div class="w-12 h-12">
-          <Show when={icon()}>
-            {(icon) => <img src={icon()} class="w-full h-full skill-icon" />}
-          </Show>
-        </div>
+      <summary class="flex flex-row items-center p-[0.25em] gap-[0.25em] cursor-pointer skill-header">
+        <Show when={icon()} fallback={<div class="w-[3em] h-[3em]" />}>
+          {(icon) => (
+            <div
+              class="skill-icon"
+              style={{ "mask-image": `url(${icon()})` }}
+            />
+          )}
+        </Show>
         <div class="flex flex-col">
-          <h3>
+          <h3 class="skill-name">
             {data()?.name ??
               assetsManager().getNameSync(props.input.definitionId) ??
               props.input.definitionId}
           </h3>
-          <div class="h-5 flex flex-row items-center gap-1">
-            <span class="text-xs">{skillTypeText()}</span>
+          <div class="flex flex-row items-center">
+            <span class="skill-type mr-[0.5em]">{skillTypeText()}</span>
             <PlayCostList playCost={playCost()} />
           </div>
         </div>
       </summary>
-      <Switch>
-        <Match when={data.error}>{t("loadFailed")}</Match>
-        <Match when={data.state === "pending"}>{t("loading")}</Match>
-        <Match when={data()}>
-          {(data) => (
-            <div class="p-2">
+      <div class="p-[0.5em]">
+        <Switch>
+          <Match when={data.error}>{t("loadFailed")}</Match>
+          <Match when={data.state === "pending"}>{t("loading")}</Match>
+          <Match when={data()}>
+            {(data) => (
               <Description
                 {...props}
                 definitionId={props.input.definitionId}
@@ -244,23 +258,23 @@ export function Skill(props: ExpandableCardDataProps) {
                 keyMap={data().keyMap}
                 onRequestExplain={props.onRequestExplain}
               />
-            </div>
-          )}
-        </Match>
-      </Switch>
-      <p
-        class="text-xs font-mono text-yellow-6"
-        classList={{
-          "mx-2 mb-2": props.asChild,
-        }}
-      >
-        DefID: <span class="select-text">{props.input.definitionId}</span>
-      </p>
+            )}
+          </Match>
+        </Switch>
+        <IdBox defId={props.input.definitionId} />
+      </div>
     </details>
   );
 }
 
 export function Entity(props: ExpandableCardDataProps) {
+  const state = createMemo(() => {
+    if (props.input.from === "definitionId") {
+      return null;
+    } else {
+      return props.input.state as PbEntityState;
+    }
+  });
   const { assetsManager, t } = useAssetsManager();
   const [data] = createResource(
     () => [props.input.definitionId, assetsManager()] as const,
@@ -268,7 +282,7 @@ export function Entity(props: ExpandableCardDataProps) {
   );
   const [icon] = createResource(
     () => [props.input.definitionId, assetsManager()] as const,
-    ([defId, manager]) => manager.getImageUrl(defId),
+    ([defId, manager]) => manager.getImageUrl(defId, { type: "icon" }),
   );
   const [entityTypeText, setEntityTypeText] = createSignal("");
 
@@ -279,74 +293,56 @@ export function Entity(props: ExpandableCardDataProps) {
   });
   return (
     <details
-      class={`flex flex-col group ${props.class ?? ""}`}
+      class={`flex flex-col skill-wrap group ${props.class ?? ""}`}
       open={!props.asChild}
     >
-      <summary class="flex flex-row items-center gap-2 cursor-pointer rounded-md group-not-open:bg-yellow-2 transition-colors">
-        <div class="relative h-12">
-          <Show when={icon()} fallback={<div class="w-12 h-12" />}>
-            {(icon) => <img src={icon()} class="h-full" />}
+      <summary class="flex flex-row items-center p-[0.25em] gap-[0.25em] cursor-pointer skill-header">
+        <div class="w-[3em] h-[3em] grid children:grid-area-[1/1]">
+          <Show when={icon()}>
+            {(icon) => <img src={icon()} class="w-[3em] h-[3em]" />}
           </Show>
           <Show
             when={
-              props.input.from === "state" &&
-              typeof props.input.variableValue === "number" &&
-              props.input
+              state() !== null && typeof state()!.variableValue === "number"
             }
-            keyed
           >
-            {(input) => (
-              <div class="absolute right-0 bottom-0 b-yellow-1 b-2 bg-yellow-8 text-yellow-1 text-xs line-height-0 h-4 w-4 rounded-full flex items-center justify-center">
-                {input.variableValue}
-              </div>
-            )}
+            <div class="place-self-end rounded-full entity-variable">
+              {state()!.variableValue}
+            </div>
           </Show>
         </div>
         <div class="flex flex-col">
-          <h3>
+          <h3 class="skill-name">
             {data()?.name ??
               assetsManager().getNameSync(props.input.definitionId) ??
               props.input.definitionId}
           </h3>
-          <div class="h-5 flex flex-row items-center gap-1">
-            <span class="text-xs">{entityTypeText()}</span>
-          </div>
+          <span class="skill-type">{entityTypeText()}</span>
         </div>
       </summary>
-      <Switch>
-        <Match when={data.error}>{t("loadFailed")}</Match>
-        <Match when={data.state === "pending"}>{t("loading")}</Match>
-        <Match when={data()}>
-          {(data) => (
-            <div class="p-2">
+      <div class="p-2">
+        <Switch>
+          <Match when={data.error}>{t("loadFailed")}</Match>
+          <Match when={data.state === "pending"}>{t("loading")}</Match>
+          <Match when={data()}>
+            {(data) => (
               <Description
                 {...props}
-                keyMap={
-                  props.input.from === "state"
-                    ? props.input.descriptionDictionary
-                    : {}
-                }
+                keyMap={state() ? state()!.descriptionDictionary : {}}
                 definitionId={props.input.definitionId}
                 description={
                   data().rawPlayingDescription ?? data().rawDescription
                 }
                 onRequestExplain={props.onRequestExplain}
               />
-            </div>
-          )}
-        </Match>
-      </Switch>
-      <p class="mt-2 text-xs font-mono text-yellow-6">
-        DefID: <span class="select-text">{props.input.definitionId}</span>
-        <Show when={props.input.from === "state" && props.input} keyed>
-          {(input) => (
-            <>
-              <span class="inline-block w-1em" />
-              ID: <span class="select-text">{input.id}</span>
-            </>
-          )}
-        </Show>
-      </p>
+            )}
+          </Match>
+        </Switch>
+        <IdBox
+          defId={props.input.definitionId}
+          id={state() ? state()!.id : void 0}
+        />
+      </div>
     </details>
   );
 }
@@ -405,44 +401,21 @@ export function Reference(props: ReferenceProps) {
     () => [props.definitionId, assetsManager()] as const,
     ([defId, manager]) => manager.getData(defId) as Promise<SkillRawData>,
   );
-  const [image] = createResource(
-    () => [props.definitionId, assetsManager()] as const,
-    ([defId, manager]) => manager.getImageUrl(defId),
-  );
   return (
-    <div>
-      <Show when={props.includesImage}>
-        <div class="w-8 h-11 float-start mr-1 justify-center overflow-hidden relative rounded-1">
-          <Show when={image()}>
-            {(image) => (
-              <img
-                src={image()}
-                class="absolute w-full top-50% left-50% translate-x--50% translate-y--50%"
-                classList={{
-                  "skill-icon":
-                    data.state === "ready" &&
-                    data()?.type?.startsWith("GCG_SKILL_"),
-                }}
-              />
-            )}
-          </Show>
-        </div>
-      </Show>
-      <h4 class="flex flex-row items-center justify-between">
-        <span class="font-bold">
+    <>
+      <h4 class="flex flex-row items-center justify-between mb-[0.25em]">
+        <span class="keyword-name">
           {data()?.name ??
             assetsManager().getNameSync(props.definitionId) ??
             props.definitionId}
         </span>
         <Show when={data.state === "ready" && data()}>
           {(data) => (
-            <span class="text-xs text-yellow-7">
-              {typeTagText(data().type, t)}
-            </span>
+            <span class="keyword-type">{typeTagText(data().type, t)}</span>
           )}
         </Show>
       </h4>
-      <div class="text-sm">
+      <div class="keyword-description">
         <Switch>
           <Match when={data.error}>{t("loadFailed")}</Match>
           <Match when={data.state === "pending"}>{t("loading")}</Match>
@@ -458,10 +431,8 @@ export function Reference(props: ReferenceProps) {
             )}
           </Match>
         </Switch>
-        <p class="text-xs font-mono text-yellow-6">
-          DefID: <span class="select-text">{props.definitionId}</span>
-        </p>
       </div>
-    </div>
+      <IdBox defId={props.definitionId} />
+    </>
   );
 }

--- a/packages/card-data-viewer/src/Entity.tsx
+++ b/packages/card-data-viewer/src/Entity.tsx
@@ -48,7 +48,6 @@ import { IdBox } from "./IdBox";
 export interface CardDataProps {
   class?: string;
   input: ViewerInput;
-  includesImage: boolean;
   onRequestExplain?: (id: number) => void;
 }
 
@@ -65,10 +64,6 @@ export function Character(props: CardDataProps) {
     () => [props.input.definitionId, assetsManager()] as const,
     ([defId, manager]) => manager.getData(defId) as Promise<CharacterRawData>,
   );
-  const [image] = createResource(
-    () => [props.input.definitionId, assetsManager()] as const,
-    ([defId, manager]) => manager.getImageUrl(defId, { type: "icon" }),
-  );
   const hpText = () =>
     state() ? `${state()!.health}/${state()!.maxHealth}` : `${data()!.hp}`;
   const mpText = () =>
@@ -83,13 +78,6 @@ export function Character(props: CardDataProps) {
         <Match when={data()}>
           {(data) => (
             <>
-              <Show when={props.includesImage}>
-                <div class="w-[3.75em] h-[3.75em] float-start mr-[0.5em] mb-[0.5em]">
-                  <Show when={image()}>
-                    {(image) => <img src={image()} class="w-full h-full" />}
-                  </Show>
-                </div>
-              </Show>
               <h3 class="card-name">{data().name}</h3>
               <dl class="flex flex-row gap-[0.25em] mb-[0.25em] card-info">
                 <dt>HP</dt>
@@ -98,7 +86,7 @@ export function Character(props: CardDataProps) {
                 <dd class="font-bold">{mpText()}</dd>
               </dl>
               <Tags tags={data().tags} />
-              <ul class="clear-both flex flex-col gap-[0.5em]">
+              <ul class="flex flex-col gap-[0.5em]">
                 <For each={data().skills}>
                   {(skill) => (
                     <Show when={!skill.hidden}>
@@ -140,10 +128,6 @@ export function ActionCard(props: CardDataProps) {
     () => [props.input.definitionId, assetsManager()] as const,
     ([defId, manager]) => manager.getData(defId) as Promise<ActionCardRawData>,
   );
-  const [image] = createResource(
-    () => [props.input.definitionId, assetsManager()] as const,
-    ([defId, manager]) => manager.getImageUrl(defId),
-  );
   return (
     <div class={props.class}>
       <Switch>
@@ -152,21 +136,12 @@ export function ActionCard(props: CardDataProps) {
         <Match when={data()}>
           {(data) => (
             <>
-              <Show when={props.includesImage}>
-                <div class="w-[4em] float-start mr-2">
-                  <Show when={image()}>
-                    {(image) => <img src={image()} class="w-full" />}
-                  </Show>
-                </div>
-              </Show>
-              <div class="flex flex-col mb-[0.25em]">
-                <h3 class="card-name">{data().name}</h3>
-                <div class="flex flex-row items-center">
-                  <span class="skill-type mr-[0.5em]">
-                    {typeTagText(data().type, t)}
-                  </span>
-                  <PlayCostList playCost={data().playCost} />
-                </div>
+              <h3 class="card-name">{data().name}</h3>
+              <div class="flex flex-row items-center mb-[0.25em]">
+                <span class="skill-type mr-[0.5em]">
+                  {typeTagText(data().type, t)}
+                </span>
+                <PlayCostList playCost={data().playCost} />
               </div>
               <Tags tags={data().tags} />
               <div>
@@ -350,7 +325,6 @@ export function Entity(props: ExpandableCardDataProps) {
 export interface CardDefinitionProps {
   class?: string;
   definitionId: number;
-  includesImage: boolean;
 }
 
 export function Keyword(props: CardDefinitionProps) {

--- a/packages/card-data-viewer/src/Entity.tsx
+++ b/packages/card-data-viewer/src/Entity.tsx
@@ -160,13 +160,15 @@ export function ActionCard(props: CardDataProps) {
                 </Show>
               </div>
               <Tags tags={data().tags} />
-              <Description
-                {...props}
-                keyMap={state() ? state()!.descriptionDictionary : {}}
-                definitionId={props.input.definitionId}
-                description={rawDescription()!}
-                onRequestExplain={props.onRequestExplain}
-              />
+              <div class="px-[0.5em]">
+                <Description
+                  {...props}
+                  keyMap={state() ? state()!.descriptionDictionary : {}}
+                  definitionId={props.input.definitionId}
+                  description={rawDescription()!}
+                  onRequestExplain={props.onRequestExplain}
+                />
+              </div>
             </>
           )}
         </Match>

--- a/packages/card-data-viewer/src/Entity.tsx
+++ b/packages/card-data-viewer/src/Entity.tsx
@@ -206,14 +206,14 @@ export function Skill(props: ExpandableCardDataProps) {
   });
   return (
     <details
-      class={`flex flex-col min-h-0 skill-wrap group ${props.class ?? ""}`}
+      class={`flex flex-col min-h-0 skill-wrap ${props.class ?? ""}`}
       open={!props.asChild}
     >
       <summary class="flex flex-row items-center p-[0.25em] gap-[0.25em] cursor-pointer skill-header">
-        <Show when={icon()} fallback={<div class="w-[3em] h-[3em]" />}>
+        <Show when={icon()} fallback={<div class="w-[3em] h-[3em] shrink-0" />}>
           {(icon) => (
             <div
-              class="skill-icon"
+              class="skill-icon shrink-0"
               style={{ "mask-image": `url(${icon()})` }}
             />
           )}
@@ -280,11 +280,11 @@ export function Entity(props: ExpandableCardDataProps) {
   });
   return (
     <details
-      class={`flex flex-col min-h-0 skill-wrap group ${props.class ?? ""}`}
+      class={`flex flex-col min-h-0 skill-wrap ${props.class ?? ""}`}
       open={!props.asChild}
     >
       <summary class="flex flex-row items-center p-[0.25em] gap-[0.25em] cursor-pointer skill-header">
-        <div class="w-[3em] h-[3em] grid children:grid-area-[1/1]">
+        <div class="w-[3em] h-[3em] grid children:grid-area-[1/1] shrink-0">
           <Show when={icon()}>
             {(icon) => <img src={icon()} class="w-[3em] h-[3em]" />}
           </Show>

--- a/packages/card-data-viewer/src/Entity.tsx
+++ b/packages/card-data-viewer/src/Entity.tsx
@@ -43,7 +43,7 @@ import { IdBox } from "./IdBox";
 export interface CardDataProps {
   class?: string;
   input: ViewerInput;
-  onRequestExplain?: (id: number) => void;
+  onRequestExplain?: (id: number | null) => void;
 }
 
 export function Character(props: CardDataProps) {
@@ -160,15 +160,13 @@ export function ActionCard(props: CardDataProps) {
                 </Show>
               </div>
               <Tags tags={data().tags} />
-              <div>
-                <Description
-                  {...props}
-                  keyMap={state() ? state()!.descriptionDictionary : {}}
-                  definitionId={props.input.definitionId}
-                  description={rawDescription()!}
-                  onRequestExplain={props.onRequestExplain}
-                />
-              </div>
+              <Description
+                {...props}
+                keyMap={state() ? state()!.descriptionDictionary : {}}
+                definitionId={props.input.definitionId}
+                description={rawDescription()!}
+                onRequestExplain={props.onRequestExplain}
+              />
             </>
           )}
         </Match>
@@ -309,7 +307,7 @@ export function Entity(props: ExpandableCardDataProps) {
           <span class="skill-type">{entityTypeText()}</span>
         </div>
       </summary>
-      <div class="p-2">
+      <div class="p-[0.5em]">
         <Switch>
           <Match when={data.error}>{t("loadFailed")}</Match>
           <Match when={data.state === "pending"}>{t("loading")}</Match>
@@ -348,33 +346,26 @@ export function Keyword(props: CardDefinitionProps) {
     ([defId, manager]) => manager.getData(defId) as Promise<KeywordRawData>,
   );
   return (
-    <div class={props.class}>
-      <h3>
-        <span class="text-yellow-7">{t("rulesExplanation")}</span>
-        <span class="font-bold">
-          {data()?.name ??
-            assetsManager().getNameSync(props.definitionId) ??
-            props.definitionId}
-        </span>
+    <div class={`px-[0.5em] ${props.class ?? ""}`}>
+      <h3 class="keyword-name">
+        {data()?.name ??
+          assetsManager().getNameSync(props.definitionId) ??
+          props.definitionId}
       </h3>
       <Switch>
         <Match when={data.error}>{t("loadFailed")}</Match>
         <Match when={data.state === "pending"}>{t("loading")}</Match>
         <Match when={data()}>
           {(data) => (
-            <div class="p-2">
-              <Description
-                {...props}
-                definitionId={props.definitionId}
-                description={data().rawDescription}
-              />
-            </div>
+            <Description
+              {...props}
+              definitionId={props.definitionId}
+              description={data().rawDescription}
+            />
           )}
         </Match>
       </Switch>
-      <p class="mt-2 text-xs font-mono text-yellow-6">
-        DefID: <span class="select-text">{-props.definitionId}</span>
-      </p>
+      <IdBox defId={-props.definitionId} />
     </div>
   );
 }
@@ -392,18 +383,18 @@ export function Reference(props: ReferenceProps) {
   return (
     <>
       <h4 class="flex flex-row items-center justify-between mb-[0.25em]">
-        <span class="keyword-name">
+        <span class="reference-name">
           {data()?.name ??
             assetsManager().getNameSync(props.definitionId) ??
             props.definitionId}
         </span>
         <Show when={data.state === "ready" && data()}>
           {(data) => (
-            <span class="keyword-type">{typeTagText(data().type, t)}</span>
+            <span class="reference-type">{typeTagText(data().type, t)}</span>
           )}
         </Show>
       </h4>
-      <div class="keyword-description">
+      <div class="reference-description">
         <Switch>
           <Match when={data.error}>{t("loadFailed")}</Match>
           <Match when={data.state === "pending"}>{t("loading")}</Match>

--- a/packages/card-data-viewer/src/Entity.tsx
+++ b/packages/card-data-viewer/src/Entity.tsx
@@ -126,8 +126,25 @@ export function ActionCard(props: CardDataProps) {
   const { assetsManager, t } = useAssetsManager();
   const [data] = createResource(
     () => [props.input.definitionId, assetsManager()] as const,
-    ([defId, manager]) => manager.getData(defId) as Promise<ActionCardRawData>,
+    ([defId, manager]) =>
+      manager.getData(defId) as Promise<ActionCardRawData | EntityRawData>,
   );
+  const rawDescription = () => {
+    if (state()) {
+      if (
+        props.input.type === "card" &&
+        (data() as ActionCardRawData).rawDynamicDescription
+      ) {
+        return (data() as ActionCardRawData).rawDynamicDescription;
+      } else if (
+        props.input.type === "entity" &&
+        data()!.rawPlayingDescription
+      ) {
+        return data()!.rawPlayingDescription;
+      }
+    }
+    return data()!.rawDescription;
+  };
   return (
     <div class={props.class}>
       <Switch>
@@ -141,7 +158,11 @@ export function ActionCard(props: CardDataProps) {
                 <span class="skill-type mr-[0.5em]">
                   {typeTagText(data().type, t)}
                 </span>
-                <PlayCostList playCost={data().playCost} />
+                <Show when={props.input.type === "card"}>
+                  <PlayCostList
+                    playCost={(data() as ActionCardRawData).playCost}
+                  />
+                </Show>
               </div>
               <Tags tags={data().tags} />
               <div>
@@ -149,11 +170,7 @@ export function ActionCard(props: CardDataProps) {
                   {...props}
                   keyMap={state() ? state()!.descriptionDictionary : {}}
                   definitionId={props.input.definitionId}
-                  description={
-                    (props.input.from === "state" &&
-                      data().rawDynamicDescription) ||
-                    data().rawDescription
-                  }
+                  description={rawDescription()!}
                   onRequestExplain={props.onRequestExplain}
                 />
               </div>

--- a/packages/card-data-viewer/src/IdBox.tsx
+++ b/packages/card-data-viewer/src/IdBox.tsx
@@ -1,4 +1,4 @@
-// Copyright (C) 2025 Guyutongxue
+// Copyright (C) 2026 Piovium Labs
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -13,25 +13,21 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { For, Show } from "solid-js";
-import { useAssetsManager } from "./context";
-import { typeTagText } from "./text_map";
+import { Show } from "solid-js";
 
-export interface TagProps {
-  tags: string[];
+export interface IdBoxProps {
+  defId: number;
+  id?: number;
 }
 
-export function Tags(props: TagProps) {
-  const { t } = useAssetsManager();
+export function IdBox(props: IdBoxProps) {
   return (
-    <ul class="flex flex-row gap-[0.5em] flex-wrap mb-[0.5em]">
-      <For each={props.tags}>
-        {(tag) => (
-          <Show when={typeTagText(tag, t)}>
-            {(tagText) => <li class="card-tag">{tagText()}</li>}
-          </Show>
-        )}
-      </For>
-    </ul>
+    <p class="mt-[0.5em] font-mono id-box">
+      DefID: <span class="select-text">{props.defId}</span>
+      <Show when={props.id}>
+        <span class="inline-block w-[1em]" />
+        ID: <span class="select-text">{props.id}</span>
+      </Show>
+    </p>
   );
 }

--- a/packages/card-data-viewer/src/PlayCost.tsx
+++ b/packages/card-data-viewer/src/PlayCost.tsx
@@ -42,17 +42,11 @@ export function PlayCostList(props: PlayCostProps) {
     `${UI_ASSET_URL_BASE}${COST_ICON_MAP[type]}.svg.webp`;
 
   const renderCost = () => {
-    if (props.playCost.length > 0) {
-      if (
-        props.playCost.length === 1 &&
-        props.playCost[0].type === "GCG_COST_LEGEND"
-      ) {
-        return [{ type: "GCG_COST_DICE_SAME", count: 0 }, ...props.playCost];
-      }
-      return props.playCost;
-    } else {
-      return [{ type: "GCG_COST_DICE_SAME", count: 0 }];
+    const result = [...props.playCost];
+    if (result.length === 0 || result[0].type === "GCG_COST_LEGEND") {
+      result.unshift({ type: "GCG_COST_DICE_SAME", count: 0 });
     }
+    return result;
   };
 
   return (

--- a/packages/card-data-viewer/src/PlayCost.tsx
+++ b/packages/card-data-viewer/src/PlayCost.tsx
@@ -15,12 +15,11 @@
 
 import type { PlayCost } from "@gi-tcg/assets-manager";
 import { For, Show } from "solid-js";
+import { UI_ASSET_URL_BASE } from "./CardFace";
 
 export interface PlayCostProps {
   playCost: PlayCost[];
 }
-
-const UI_ASSET_URL_BASE = "https://ui-assets.piovium.org/";
 
 export const COST_ICON_MAP: Record<string, string> = {
   GCG_COST_DICE_VOID: "DiceVoid",

--- a/packages/card-data-viewer/src/PlayCost.tsx
+++ b/packages/card-data-viewer/src/PlayCost.tsx
@@ -14,64 +14,60 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import type { PlayCost } from "@gi-tcg/assets-manager";
-import { For } from "solid-js";
+import { For, Show } from "solid-js";
 
 export interface PlayCostProps {
   playCost: PlayCost[];
 }
 
-const COLOR_MAP: Record<string, string> = {
-  GCG_COST_DICE_VOID: "#4a4a4a",
-  GCG_COST_DICE_ELECTRO: "#b380ff",
-  GCG_COST_DICE_PYRO: "#ff9955",
-  GCG_COST_DICE_DENDRO: "#a5c83b",
-  GCG_COST_DICE_CRYO: "#55ddff",
-  GCG_COST_DICE_GEO: "#ffcc00",
-  GCG_COST_DICE_HYDRO: "#3e99ff",
-  GCG_COST_DICE_ANEMO: "#80ffe6",
-  GCG_COST_DICE_SAME: "#dcd4c2",
-  GCG_COST_ENERGY: "#d0cc51",
+const UI_ASSET_URL_BASE = "https://ui-assets.piovium.org/";
+
+export const COST_ICON_MAP: Record<string, string> = {
+  GCG_COST_DICE_VOID: "DiceVoid",
+  GCG_COST_DICE_CRYO: "DiceCryo",
+  GCG_COST_DICE_HYDRO: "DiceHydro",
+  GCG_COST_DICE_PYRO: "DicePyro",
+  GCG_COST_DICE_ELECTRO: "DiceElectro",
+  GCG_COST_DICE_ANEMO: "DiceAnemo",
+  GCG_COST_DICE_GEO: "DiceGeo",
+  GCG_COST_DICE_DENDRO: "DiceDendro",
+  GCG_COST_DICE_SAME: "DiceSame",
+  GCG_COST_ENERGY: "DiceEnergyNormal",
+  GCG_COST_LEGEND: "DiceLegend",
+  GCG_COST_SPECIAL_ENERGY: "DiceEnergyMavuika",
+  GCG_COST_SKIRK_SPECIAL_ENERGY: "DiceEnergySkirk",
 };
 
 export function PlayCostList(props: PlayCostProps) {
-  const glyph = (type: string) => {
-    if (type === "GCG_COST_LEGEND") {
-      return "";
-    } else if (type === "GCG_COST_ENERGY") {
-      return "\u2726";
+  const getIconUrl = (type: string) =>
+    `${UI_ASSET_URL_BASE}${COST_ICON_MAP[type]}.svg.webp`;
+
+  const renderCost = () => {
+    if (props.playCost.length > 0) {
+      if (
+        props.playCost.length === 1 &&
+        props.playCost[0].type === "GCG_COST_LEGEND"
+      ) {
+        return [{ type: "GCG_COST_DICE_SAME", count: 0 }, ...props.playCost];
+      }
+      return props.playCost;
     } else {
-      return "\u2b22";
-    }
-  };
-  const textColor = (type: string) => {
-    if (["GCG_COST_ENERGY", "GCG_COST_DICE_SAME"].includes(type)) {
-      return "black";
-    } else {
-      return "white";
+      return [{ type: "GCG_COST_DICE_SAME", count: 0 }];
     }
   };
 
   return (
-    <div class="flex flex-row">
-      <For each={props.playCost}>
+    <>
+      <For each={renderCost()}>
         {(item) => (
-          <div class="relative">
-            <div
-              class="line-height-none text-2xl data-[legend]:w-3 data-[legend]:h-3 data-[legend]:bg-gradient-to-r data-[legend]:rotate-45 from-purple-500 to-blue-500"
-              bool:data-legend={item.type === "GCG_COST_LEGEND"}
-              style={{ color: COLOR_MAP[item.type] }}
-            >
-              {glyph(item.type)}
-            </div>
-            <div
-              class="line-height-none absolute left-50% top-50% translate-x--50% translate-y--50% text-xs"
-              style={{ color: textColor(item.type) }}
-            >
-              {item.count}
-            </div>
+          <div class="grid place-items-center children:grid-area-[1/1]">
+            <img class="w-[1.5em] h-[1.5em]" src={getIconUrl(item.type)} />
+            <Show when={item.type !== "GCG_COST_LEGEND"}>
+              <div class="play-cost">{item.count}</div>
+            </Show>
           </div>
         )}
       </For>
-    </div>
+    </>
   );
 }

--- a/packages/card-data-viewer/src/dev.tsx
+++ b/packages/card-data-viewer/src/dev.tsx
@@ -22,7 +22,6 @@ function App() {
   const enAssetsManager = new AssetsManager({ language: "CHS" });
   const { CardDataViewer, showCharacter, showState, showCard, showSkill } =
     createCardDataViewer({
-      includesImage: true,
       assetsManager: () => enAssetsManager,
       locale: () => "zh-CN"
     });

--- a/packages/card-data-viewer/src/dev.tsx
+++ b/packages/card-data-viewer/src/dev.tsx
@@ -91,14 +91,18 @@ function App() {
     //     },
     //   ],
     // });
-    // showState("entity", {
-    //   id: -5000001,
-    //   definitionId: 113041,
-    //   descriptionDictionary: {},
-    //   hasUsagePerRound: false,
-    //   variableName: "usage",
-    //   variableValue: 2,
-    // });
+    showState("entity", {
+      id: -5000001,
+      definitionId: 113041,
+      definitionCost: [],
+      tags: 0,
+      descriptionDictionary: {},
+      hasUsagePerRound: false,
+      variableName: "usage",
+      variableValue: 2,
+      type: 4,
+      attachment: []
+    });
     // showCard(212111);
     // showCharacter(1610);
     // showSkill(12111);

--- a/packages/card-data-viewer/src/dev.tsx
+++ b/packages/card-data-viewer/src/dev.tsx
@@ -19,23 +19,23 @@ import { render } from "solid-js/web";
 import { AssetsManager } from "@gi-tcg/assets-manager";
 
 function App() {
-  const enAssetsManager = new AssetsManager({ language: "EN" });
+  const enAssetsManager = new AssetsManager({ language: "CHS" });
   const { CardDataViewer, showCharacter, showState, showCard, showSkill } =
     createCardDataViewer({
       includesImage: true,
       assetsManager: () => enAssetsManager,
-      locale: () => "en"
+      locale: () => "zh-CN"
     });
   onMount(() => {
     showState(
       "character",
       {
         id: -500001,
-        definitionId: 1304,
+        definitionId: 1212,
         aura: 0,
         defeated: false,
-        health: 10,
-        maxHealth: 10,
+        health: 5,
+        maxHealth: 100,
         energy: 2,
         maxEnergy: 2,
         tags: 0,

--- a/packages/card-data-viewer/src/dev.tsx
+++ b/packages/card-data-viewer/src/dev.tsx
@@ -91,7 +91,7 @@ function App() {
     //     },
     //   ],
     // });
-    // showState("summon", {
+    // showState("entity", {
     //   id: -5000001,
     //   definitionId: 113041,
     //   descriptionDictionary: {},

--- a/packages/card-data-viewer/src/index.tsx
+++ b/packages/card-data-viewer/src/index.tsx
@@ -41,12 +41,23 @@ export interface RegisterResult {
   readonly showCharacter: (id: number, opt?: ShowCardDataViewerOption) => void;
   readonly showSkill: (id: number, opt?: ShowCardDataViewerOption) => void;
   readonly showCard: (id: number, opt?: ShowCardDataViewerOption) => void;
-  readonly showState: (
-    type: "character" | "entity" | "card",
-    state: PbCharacterState | PbEntityState,
-    extra: PbEntityState[],
-    opt?: ShowCardDataViewerOption,
-  ) => void;
+  readonly showState: {
+    (
+      type: "character",
+      state: PbCharacterState,
+      combatStatuses: PbEntityState[],
+      opt?: ShowCardDataViewerOption,
+    ): void;
+    /**
+     * - Pass in type = "entity" for on-stage entities (which reads `rawPlayingDescription`)
+     * - Pass in type = "card" for off-stage entities (which reads `rawDynamicDescription`)
+     */
+    (
+      type: "entity" | "card",
+      state: PbEntityState,
+      opt?: ShowCardDataViewerOption,
+    ): void;
+  };
 
   readonly hide: () => void;
 }
@@ -128,11 +139,17 @@ export function createCardDataViewer(
     showState: (
       type: StateType,
       state: PbCharacterState | PbEntityState,
-      extra?: PbEntityState[],
+      combatStatusesOrOpt?: PbEntityState[] | ShowCardDataViewerOption,
       opt?: ShowCardDataViewerOption,
     ) => {
+      const extra =
+        type === "character" ? (combatStatusesOrOpt as PbEntityState[]) : [];
+      const options =
+        type === "character"
+          ? opt
+          : (combatStatusesOrOpt as ShowCardDataViewerOption | undefined);
       setMainImageDefId(
-        opt?.includesImage === false ? null : state.definitionId,
+        options?.includesImage === false ? null : state.definitionId,
       );
       setInputs([
         // main item

--- a/packages/card-data-viewer/src/index.tsx
+++ b/packages/card-data-viewer/src/index.tsx
@@ -55,21 +55,32 @@ export interface RegisterResult {
 
 export interface CreateCardDataViewerOption {
   assetsManager?: Accessor<AssetsManager>;
-  includesImage?: boolean;
   locale?: Accessor<Locale>;
+}
+
+export interface ShowCardDataViewerOption {
+  includesImage?: boolean;
 }
 
 export function createCardDataViewer(
   option: CreateCardDataViewerOption = {},
 ): RegisterResult {
   const localeGetter = createMemo(() => option.locale?.() ?? "zh-CN");
-  const assetsManagerGetter = createMemo(() => option.assetsManager?.() ?? DEFAULT_ASSETS_MANAGER);
+  const assetsManagerGetter = createMemo(
+    () => option.assetsManager?.() ?? DEFAULT_ASSETS_MANAGER,
+  );
   const dict = createMemo(() => translations[localeGetter()]);
 
   const [shown, setShown] = createSignal(false);
+  const [includesImage, setIncludesImage] = createSignal(false);
   const [inputs, setInputs] = createSignal<ViewerInput[]>([]);
 
-  const showDef = (definitionId: number, type: StateType) => {
+  const showDef = (
+    definitionId: number,
+    type: StateType,
+    opt?: ShowCardDataViewerOption,
+  ) => {
+    setIncludesImage(opt?.includesImage ?? false);
     setInputs([
       {
         from: "definitionId",
@@ -103,24 +114,26 @@ export function createCardDataViewer(
         <CardDataViewerContainer
           shown={shown()}
           inputs={inputs()}
-          includesImage={option.includesImage ?? false}
+          includesImage={includesImage()}
         />
       </AssetsContext.Provider>
     ),
-    showCard: (id) => {
-      showDef(id, "card");
+    showCard: (id: number, opt?: ShowCardDataViewerOption) => {
+      showDef(id, "card", opt);
     },
-    showCharacter: (id) => {
-      showDef(id, "character");
+    showCharacter: (id: number, opt?: ShowCardDataViewerOption) => {
+      showDef(id, "character", opt);
     },
-    showSkill: (id) => {
-      showDef(id, "skill");
+    showSkill: (id: number, opt?: ShowCardDataViewerOption) => {
+      showDef(id, "skill", opt);
     },
     showState: (
       type: StateType,
       state: PbCharacterState | PbEntityState,
       combatStatuses?: PbEntityState[],
+      opt?: ShowCardDataViewerOption,
     ) => {
+      setIncludesImage(opt?.includesImage ?? true);
       setInputs([
         // main item
         mapStateToInput(state, type),

--- a/packages/card-data-viewer/src/index.tsx
+++ b/packages/card-data-viewer/src/index.tsx
@@ -88,9 +88,7 @@ export function createCardDataViewer(
     id: st.id,
     type,
     definitionId: st.definitionId,
-    descriptionDictionary:
-      "descriptionDictionary" in st ? st.descriptionDictionary : {},
-    variableValue: "variableValue" in st ? st.variableValue : void 0,
+    state: st,
   });
 
   return {

--- a/packages/card-data-viewer/src/index.tsx
+++ b/packages/card-data-viewer/src/index.tsx
@@ -47,7 +47,7 @@ export interface RegisterResult {
       character: PbCharacterState,
       combatStatuses: PbEntityState[],
     ): void;
-    (type: "summon" | "support", entity: PbEntityState): void;
+    (type: "entity", entity: PbEntityState): void;
     (type: "card", card: PbEntityState): void;
   };
   readonly hide: () => void;

--- a/packages/card-data-viewer/src/index.tsx
+++ b/packages/card-data-viewer/src/index.tsx
@@ -38,18 +38,16 @@ import { translator } from "@solid-primitives/i18n";
 
 export interface RegisterResult {
   readonly CardDataViewer: () => JSX.Element;
-  readonly showCharacter: (id: number) => void;
-  readonly showSkill: (id: number) => void;
-  readonly showCard: (id: number) => void;
-  readonly showState: {
-    (
-      type: "character",
-      character: PbCharacterState,
-      combatStatuses: PbEntityState[],
-    ): void;
-    (type: "entity", entity: PbEntityState): void;
-    (type: "card", card: PbEntityState): void;
-  };
+  readonly showCharacter: (id: number, opt?: ShowCardDataViewerOption) => void;
+  readonly showSkill: (id: number, opt?: ShowCardDataViewerOption) => void;
+  readonly showCard: (id: number, opt?: ShowCardDataViewerOption) => void;
+  readonly showState: (
+    type: "character" | "entity" | "card",
+    state: PbCharacterState | PbEntityState,
+    extra: PbEntityState[],
+    opt?: ShowCardDataViewerOption,
+  ) => void;
+
   readonly hide: () => void;
 }
 
@@ -130,7 +128,7 @@ export function createCardDataViewer(
     showState: (
       type: StateType,
       state: PbCharacterState | PbEntityState,
-      combatStatuses?: PbEntityState[],
+      extra?: PbEntityState[],
       opt?: ShowCardDataViewerOption,
     ) => {
       setMainImageDefId(
@@ -150,9 +148,7 @@ export function createCardDataViewer(
           ? state.attachment.map((st) => mapStateToInput(st, "attachment"))
           : []),
         // combat statuses (2nd argument)
-        ...(combatStatuses ?? []).map((st) =>
-          mapStateToInput(st, "combatStatus"),
-        ),
+        ...(extra ?? []).map((st) => mapStateToInput(st, "combatStatus")),
       ]);
       setShown(true);
     },

--- a/packages/card-data-viewer/src/index.tsx
+++ b/packages/card-data-viewer/src/index.tsx
@@ -72,7 +72,7 @@ export function createCardDataViewer(
   const dict = createMemo(() => translations[localeGetter()]);
 
   const [shown, setShown] = createSignal(false);
-  const [includesImage, setIncludesImage] = createSignal(false);
+  const [mainImageDefId, setMainImageDefId] = createSignal<number | null>(null);
   const [inputs, setInputs] = createSignal<ViewerInput[]>([]);
 
   const showDef = (
@@ -80,7 +80,7 @@ export function createCardDataViewer(
     type: StateType,
     opt?: ShowCardDataViewerOption,
   ) => {
-    setIncludesImage(opt?.includesImage ?? false);
+    setMainImageDefId(opt?.includesImage ? definitionId : null);
     setInputs([
       {
         from: "definitionId",
@@ -114,7 +114,7 @@ export function createCardDataViewer(
         <CardDataViewerContainer
           shown={shown()}
           inputs={inputs()}
-          includesImage={includesImage()}
+          mainImageDefId={mainImageDefId()}
         />
       </AssetsContext.Provider>
     ),
@@ -133,7 +133,9 @@ export function createCardDataViewer(
       combatStatuses?: PbEntityState[],
       opt?: ShowCardDataViewerOption,
     ) => {
-      setIncludesImage(opt?.includesImage ?? true);
+      setMainImageDefId(
+        opt?.includesImage === false ? null : state.definitionId,
+      );
       setInputs([
         // main item
         mapStateToInput(state, type),
@@ -143,6 +145,7 @@ export function createCardDataViewer(
               mapStateToInput(st, st.equipment ? "equipment" : "status"),
             )
           : []),
+        // action card zone entities
         ...("attachment" in state
           ? state.attachment.map((st) => mapStateToInput(st, "attachment"))
           : []),

--- a/packages/card-data-viewer/src/locales/en.ts
+++ b/packages/card-data-viewer/src/locales/en.ts
@@ -5,6 +5,7 @@ export default {
   loadFailed: "Load failed",
   equipment: "Character Equipment",
   status: "Character Status",
+  equipAndStatus: "Equipment & Status",
   combatStatus: "Team Combat Status",
   attachment: "Applied Effect Status",
   rulesExplanation: "Detailed Rules",

--- a/packages/card-data-viewer/src/locales/en.ts
+++ b/packages/card-data-viewer/src/locales/en.ts
@@ -6,7 +6,7 @@ export default {
   equipment: "Character Equipment",
   status: "Character Status",
   combatStatus: "Team Combat Status",
-  attachmentStatus: "Applied Effect Status",
+  attachment: "Applied Effect Status",
   rulesExplanation: "Detailed Rules:",
   skillNormal: "Normal Attack",
   skillElemental: "Elemental Skill",

--- a/packages/card-data-viewer/src/locales/en.ts
+++ b/packages/card-data-viewer/src/locales/en.ts
@@ -7,7 +7,7 @@ export default {
   status: "Character Status",
   combatStatus: "Team Combat Status",
   attachment: "Applied Effect Status",
-  rulesExplanation: "Detailed Rules:",
+  rulesExplanation: "Detailed Rules",
   skillNormal: "Normal Attack",
   skillElemental: "Elemental Skill",
   skillBurst: "Elemental Burst",

--- a/packages/card-data-viewer/src/locales/zh-CN.ts
+++ b/packages/card-data-viewer/src/locales/zh-CN.ts
@@ -18,6 +18,7 @@ export default {
   loadFailed: "加载失败",
   equipment: "角色装备",
   status: "角色状态",
+  equipAndStatus: "角色装备与状态",
   combatStatus: "阵营出战状态",
   attachment: "附着效果状态",
   rulesExplanation: "规则解释",

--- a/packages/card-data-viewer/src/locales/zh-CN.ts
+++ b/packages/card-data-viewer/src/locales/zh-CN.ts
@@ -20,7 +20,7 @@ export default {
   status: "角色状态",
   combatStatus: "阵营出战状态",
   attachment: "附着效果状态",
-  rulesExplanation: "规则解释：",
+  rulesExplanation: "规则解释",
   skillNormal: "普通攻击",
   skillElemental: "元素战技",
   skillBurst: "元素爆发",

--- a/packages/card-data-viewer/src/locales/zh-CN.ts
+++ b/packages/card-data-viewer/src/locales/zh-CN.ts
@@ -19,7 +19,7 @@ export default {
   equipment: "角色装备",
   status: "角色状态",
   combatStatus: "阵营出战状态",
-  attachmentStatus: "附着效果状态",
+  attachment: "附着效果状态",
   rulesExplanation: "规则解释：",
   skillNormal: "普通攻击",
   skillElemental: "元素战技",

--- a/packages/card-data-viewer/src/style.css
+++ b/packages/card-data-viewer/src/style.css
@@ -29,7 +29,7 @@
   --skill-icon-color: #713f12;
   --id-color: #ca8a04;
 
-  &[data-light] {
+  &:where([data-light] > *) {
     --panel-background-color: #f7f7eb;
     --panel-border-color: #b4967e;
     --text-color-h1: #716864;
@@ -47,7 +47,7 @@
     --id-color: #ca8a04;
   }
 
-  &[data-dark] {
+  &:where([data-dark] > *) {
     --panel-background-color: #2e3740;
     --panel-border-color: #404d5c;
     --text-color-h1: #cad8ea;

--- a/packages/card-data-viewer/src/style.css
+++ b/packages/card-data-viewer/src/style.css
@@ -14,7 +14,7 @@
   font-size: 1rem;
 
   --panel-width: 18em; 
-  --card-width: 14em;
+  --card-width: 10em;
   /*
   --panel-background-color: #fef9c3;
   --panel-border-color: #854d0e;

--- a/packages/card-data-viewer/src/style.css
+++ b/packages/card-data-viewer/src/style.css
@@ -164,11 +164,13 @@
     color: var(--text-color-h4);
     padding: 0.125em;
     font-weight: bold;
-    margin-bottom: 0.5em;
   }
 
-  .entity-category:not(:first-child) {
-    margin-top: 0.5em;
+  .entity-category[data-show-combine-button]::after {
+    content: "⇌";
+    position: absolute;
+    font-weight: bold;
+    right: 1em;
   }
 
   .entity-variable {

--- a/packages/card-data-viewer/src/style.css
+++ b/packages/card-data-viewer/src/style.css
@@ -7,13 +7,12 @@
   gap: 0.5em;
   min-height: 0;
 
-
   height: 100%;
   width: 100%;
 
   font-size: 1rem;
 
-  --panel-width: 18em; 
+  --panel-width: 18em;
   --card-width: 10em;
   /*
   --panel-background-color: #fef9c3;
@@ -22,31 +21,19 @@
   --text-color-content: var(--text-color-header);
   */
 
-  --panel-background-color: #2E3740;
-  --panel-border-color: #404D5C;
-  --text-color-h1: #CAD8EA;
-  --text-color-h2: #EDE5DA;
-  --text-color-h3: #D3BC8E;
+  --panel-background-color: #2e3740;
+  --panel-border-color: #404d5c;
+  --text-color-h1: #cad8ea;
+  --text-color-h2: #ede5da;
+  --text-color-h3: #d3bc8e;
   --text-color-h4: #758498;
-  --text-color-content: #B2AFA8;
-  --text-color-strong: #FFFFFF;
-  --item-background-color: #22292F;
-  --item-border-color: #434E5A;
-  --catalog-background-color: #252D37;
-  --keyword-border-color: #62686F;
+  --text-color-content: #b2afa8;
+  --text-color-strong: #ffffff;
+  --item-background-color: #22292f;
+  --item-border-color: #434e5a;
+  --category-background-color: #252d37;
+  --keyword-border-color: #62686f;
   --id-color: #ca8a04;
-
-  ::-webkit-scrollbar {
-    width: 10px;
-    height: 10px;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background-color: darkgoldenrod;
-    border: 3px solid transparent;
-    border-radius: 5px;
-    background-clip: padding-box;
-  }
 
   .card-face {
     width: var(--card-width);
@@ -56,14 +43,17 @@
   .card-panel {
     position: relative;
     width: var(--panel-width, 18em);
-    padding: 0.5em;
+    padding: 0.5em 0.25em 0.5em 0.5em;
     border-radius: 0.375em;
     border: 0.125em solid var(--panel-border-color);
     color: var(--text-color-content);
     background-color: var(--panel-background-color);
-    overflow: auto;
+    overflow-y: auto;
     max-height: 100%;
+    min-height: 0;
     pointer-events: auto;
+    scrollbar-width: thin;
+    scrollbar-color: var(--panel-border-color) transparent;
   }
 
   .card-name {
@@ -169,9 +159,23 @@
     font-size: 0.75em;
   }
 
+  .entity-category {
+    background-color: var(--category-background-color);
+    color: var(--text-color-h4);
+    padding: 0.125em;
+    font-weight: bold;
+    margin-bottom: 0.5em;
+  }
+  
+  .entity-category:not(:first-child) {
+    margin-top: 0.5em;
+  }
+
+
   .entity-variable {
     width: 1.25em;
     height: 1.25em;
+    font-size: 1em;
     text-align: center;
     line-height: 1.25em;
     background-color: var(--keyword-border-color);

--- a/packages/card-data-viewer/src/style.css
+++ b/packages/card-data-viewer/src/style.css
@@ -29,7 +29,7 @@
   --skill-icon-color: #713f12;
   --id-color: #ca8a04;
 
-  &:where([data-light] > *) {
+  &:where([data-light], [data-light] *) {
     --panel-background-color: #f7f7eb;
     --panel-border-color: #b4967e;
     --text-color-h1: #716864;
@@ -47,7 +47,7 @@
     --id-color: #ca8a04;
   }
 
-  &:where([data-dark] > *) {
+  &:where([data-dark], [data-dark] *) {
     --panel-background-color: #2e3740;
     --panel-border-color: #404d5c;
     --text-color-h1: #cad8ea;
@@ -120,6 +120,7 @@
     width: 3em;
     height: 3em;
     mask-size: 3em 3em;
+    mask-image: var(--mask-image);
     background-color: var(--skill-icon-color);
   }
 

--- a/packages/card-data-viewer/src/style.css
+++ b/packages/card-data-viewer/src/style.css
@@ -1,7 +1,39 @@
 .gi-tcg-card-data-viewer {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  -webkit-user-select: none;
+  user-select: none;
+  gap: 0.5em;
+  min-height: 0;
+
 
   height: 100%;
   width: 100%;
+
+  font-size: 1rem;
+
+  --panel-width: 18em; 
+  /*
+  --panel-background-color: #fef9c3;
+  --panel-border-color: #854d0e;
+  --text-color-header: #713f12;
+  --text-color-content: var(--text-color-header);
+  */
+
+  --panel-background-color: #2E3740;
+  --panel-border-color: #404D5C;
+  --text-color-h1: #CAD8EA;
+  --text-color-h2: #EDE5DA;
+  --text-color-h3: #D3BC8E;
+  --text-color-h4: #758498;
+  --text-color-content: #B2AFA8;
+  --text-color-strong: #FFFFFF;
+  --item-background-color: #22292F;
+  --item-border-color: #434E5A;
+  --catalog-background-color: #252D37;
+  --keyword-border-color: #62686F;
+  --id-color: #ca8a04;
 
   ::-webkit-scrollbar {
     width: 10px;
@@ -15,11 +47,128 @@
     background-clip: padding-box;
   }
 
-  .skill-icon {
-    filter: invert(75%) sepia(100%) saturate(250%);
+  .card-panel {
+    position: relative;
+    width: var(--panel-width, 18em);
+    padding: 0.5em;
+    border-radius: 0.375em;
+    border: 0.125em solid var(--panel-border-color);
+    color: var(--text-color-content);
+    background-color: var(--panel-background-color);
+    overflow: auto;
+    max-height: 100%;
+    pointer-events: auto;
   }
-}
 
-.card-panel {
-  --at-apply: pointer-events-auto max-h-100% overflow-auto bg-yellow-1 b-yellow-8 text-yellow-9 b-solid b-1 rounded-md p-2 w-72 relative;
+  .card-name {
+    font-size: 1.25em;
+    font-weight: bold;
+    color: var(--text-color-h1);
+  }
+
+  .card-info {
+    font-size: 0.875em;
+    color: var(--text-color-content);
+  }
+
+  .card-tag {
+    background-color: var(--text-color-h1);
+    color: var(--panel-background-color);
+    font-size: 0.875em;
+    font-weight: bold;
+    padding: 0 0.5em;
+    border-radius: 0.125em;
+  }
+
+  .skill-wrap {
+    border: 0.125em solid var(--item-border-color);
+    border-radius: 0.375em;
+    overflow: clip;
+  }
+
+  .skill-header {
+    background-color: var(--item-background-color);
+  }
+
+  .skill-icon {
+    width: 3em;
+    height: 3em;
+    mask-size: 3em 3em;
+    background-color: var(--text-color-strong);
+  }
+
+  .skill-name {
+    font-size: 1em;
+    color: var(--text-color-h2);
+  }
+
+  .skill-type {
+    font-size: 0.875em;
+    color: var(--text-color-h3);
+  }
+
+  .play-cost {
+    color: white;
+    font-size: 0.875em;
+    font-weight: bold;
+    paint-order: stroke fill;
+    -webkit-text-stroke-color: black;
+    -webkit-text-stroke-width: 0.125em;
+  }
+
+  .description {
+    color: var(--text-color-content);
+    font-size: 1em;
+  }
+
+  .description-strong {
+    color: var(--text-color-strong);
+    margin-inline: 0.125em;
+  }
+
+  .description-underline {
+    color: var(--text-color-strong);
+    text-decoration-line: underline;
+    text-decoration-thickness: 0.0625em;
+    text-underline-offset: 0.1875em;
+    margin-inline: 0.125em;
+  }
+
+  .keyword {
+    border-left: 0.1875em solid var(--keyword-border-color);
+    padding-left: 0.5em;
+  }
+
+  .keyword:not(:last-child) {
+    margin-bottom: 0.5em;
+  }
+
+  .keyword-name {
+    font-size: 0.875em;
+    color: var(--text-color-strong);
+  }
+
+  .keyword-type {
+    font-size: 0.875em;
+    color: var(--text-color-h3);
+  }
+
+  .keyword-description {
+    color: var(--text-color-content);
+    font-size: 0.875em;
+  }
+
+  .id-box {
+    color: var(--id-color);
+    font-size: 0.75em;
+  }
+
+  .entity-variable {
+    width: 1.25em;
+    height: 1.25em;
+    text-align: center;
+    line-height: 1.25em;
+    background-color: var(--keyword-border-color);
+    color: var(--text-color-strong);
+  }
 }

--- a/packages/card-data-viewer/src/style.css
+++ b/packages/card-data-viewer/src/style.css
@@ -14,6 +14,7 @@
   font-size: 1rem;
 
   --panel-width: 18em; 
+  --card-width: 14em;
   /*
   --panel-background-color: #fef9c3;
   --panel-border-color: #854d0e;
@@ -45,6 +46,11 @@
     border: 3px solid transparent;
     border-radius: 5px;
     background-clip: padding-box;
+  }
+
+  .card-face {
+    width: var(--card-width);
+    aspect-ratio: 7 / 12;
   }
 
   .card-panel {

--- a/packages/card-data-viewer/src/style.css
+++ b/packages/card-data-viewer/src/style.css
@@ -10,30 +10,60 @@
   height: 100%;
   width: 100%;
 
-  font-size: 1rem;
-
   --panel-width: 18em;
   --card-width: 10em;
-  /*
+
   --panel-background-color: #fef9c3;
   --panel-border-color: #854d0e;
-  --text-color-header: #713f12;
-  --text-color-content: var(--text-color-header);
-  */
-
-  --panel-background-color: #2e3740;
-  --panel-border-color: #404d5c;
-  --text-color-h1: #cad8ea;
-  --text-color-h2: #ede5da;
-  --text-color-h3: #d3bc8e;
-  --text-color-h4: #758498;
-  --text-color-content: #b2afa8;
-  --text-color-strong: #ffffff;
-  --item-background-color: #22292f;
-  --item-border-color: #434e5a;
-  --category-background-color: #252d37;
-  --reference-border-color: #62686f;
+  --text-color-h1: #713f12;
+  --text-color-h2: #713f12;
+  --text-color-h3: #ca8a04;
+  --text-color-h4: #fef9c3;
+  --text-color-content: #854d0e;
+  --text-color-strong: #000000;
+  --item-background-color: #fef08a;
+  --item-border-color: #eab308;
+  --tag-background-color: #854d0e;
+  --category-background-color: #eab308;
+  --reference-border-color: #854d0e;
+  --skill-icon-color: #713f12;
   --id-color: #ca8a04;
+
+  &[data-light] {
+    --panel-background-color: #f7f7eb;
+    --panel-border-color: #b4967e;
+    --text-color-h1: #716864;
+    --text-color-h2: #716864;
+    --text-color-h3: #b4967e;
+    --text-color-h4: #fefef4;
+    --text-color-content: #716864;
+    --text-color-strong: #4b2300;
+    --item-background-color: #f0eadd;
+    --item-border-color: #b4967e;
+    --tag-background-color: #cab5a1;
+    --category-background-color: #cab5a1;
+    --reference-border-color: #b4967e;
+    --skill-icon-color: #716864;
+    --id-color: #ca8a04;
+  }
+
+  &[data-dark] {
+    --panel-background-color: #2e3740;
+    --panel-border-color: #404d5c;
+    --text-color-h1: #cad8ea;
+    --text-color-h2: #ede5da;
+    --text-color-h3: #d3bc8e;
+    --text-color-h4: #758498;
+    --text-color-content: #b2afa8;
+    --text-color-strong: #ffffff;
+    --item-background-color: #22292f;
+    --item-border-color: #434e5a;
+    --tag-background-color: #cad8ea;
+    --category-background-color: #252d37;
+    --reference-border-color: #62686f;
+    --skill-icon-color: #ffffff;
+    --id-color: #ca8a04;
+  }
 
   .card-face {
     width: var(--card-width);
@@ -68,7 +98,7 @@
   }
 
   .card-tag {
-    background-color: var(--text-color-h1);
+    background-color: var(--tag-background-color);
     color: var(--panel-background-color);
     font-size: 0.875em;
     font-weight: bold;
@@ -90,7 +120,7 @@
     width: 3em;
     height: 3em;
     mask-size: 3em 3em;
-    background-color: var(--text-color-strong);
+    background-color: var(--skill-icon-color);
   }
 
   .skill-name {
@@ -179,8 +209,8 @@
     font-size: 1em;
     text-align: center;
     line-height: 1.25em;
-    background-color: var(--reference-border-color);
-    color: var(--text-color-strong);
+    background-color: #333e;
+    color: white;
   }
 
   .keyword-name {

--- a/packages/card-data-viewer/src/style.css
+++ b/packages/card-data-viewer/src/style.css
@@ -32,7 +32,7 @@
   --item-background-color: #22292f;
   --item-border-color: #434e5a;
   --category-background-color: #252d37;
-  --keyword-border-color: #62686f;
+  --reference-border-color: #62686f;
   --id-color: #ca8a04;
 
   .card-face {
@@ -130,26 +130,26 @@
     margin-inline: 0.125em;
   }
 
-  .keyword {
-    border-left: 0.1875em solid var(--keyword-border-color);
+  .reference {
+    border-left: 0.1875em solid var(--reference-border-color);
     padding-left: 0.5em;
   }
 
-  .keyword:not(:last-child) {
+  .reference:not(:last-child) {
     margin-bottom: 0.5em;
   }
 
-  .keyword-name {
+  .reference-name {
     font-size: 0.875em;
     color: var(--text-color-strong);
   }
 
-  .keyword-type {
+  .reference-type {
     font-size: 0.875em;
     color: var(--text-color-h3);
   }
 
-  .keyword-description {
+  .reference-description {
     color: var(--text-color-content);
     font-size: 0.875em;
   }
@@ -166,11 +166,10 @@
     font-weight: bold;
     margin-bottom: 0.5em;
   }
-  
+
   .entity-category:not(:first-child) {
     margin-top: 0.5em;
   }
-
 
   .entity-variable {
     width: 1.25em;
@@ -178,7 +177,13 @@
     font-size: 1em;
     text-align: center;
     line-height: 1.25em;
-    background-color: var(--keyword-border-color);
+    background-color: var(--reference-border-color);
     color: var(--text-color-strong);
+  }
+
+  .keyword-name {
+    color: var(--text-color-strong);
+    font-weight: bold;
+    font-size: 1.125em;
   }
 }

--- a/packages/web-ui-core/src/components/Chessboard.tsx
+++ b/packages/web-ui-core/src/components/Chessboard.tsx
@@ -1100,7 +1100,7 @@ export function Chessboard(props: ChessboardProps) {
         item.info.combatStatus.map((x) => x.data),
       );
     } else if (item.type === "entity") {
-      dataViewerController.showState(item.info.type, item.info.data);
+      dataViewerController.showState("eneity", item.info.data);
     } else if (item.type === "skill") {
       dataViewerController.showSkill(item.info.id);
     } else if (item.type === "externalCard") {

--- a/packages/web-ui-core/src/components/Chessboard.tsx
+++ b/packages/web-ui-core/src/components/Chessboard.tsx
@@ -1005,7 +1005,7 @@ function rerenderChildren(opt: {
   };
 }
 
-type SelectingItem =
+type SelectingItem = (
   | {
       type: "card";
       info: CardInfo;
@@ -1025,7 +1025,8 @@ type SelectingItem =
   | {
       type: "externalCard";
       info: number | PbEntityState;
-    };
+    }
+) & { showImage?: boolean };
 
 export function Chessboard(props: ChessboardProps) {
   const [localProps, elProps] = splitProps(props, [
@@ -1061,7 +1062,7 @@ export function Chessboard(props: ChessboardProps) {
     assetsManager,
     locale,
   });
-  const [selectingItem, setSelectingItem] = createSignal<SelectingItem & {showImage?: boolean} | null>(
+  const [selectingItem, setSelectingItem] = createSignal<SelectingItem | null>(
     null,
   );
   /** 是否是主棋盘上被选中的卡 */
@@ -1092,7 +1093,9 @@ export function Chessboard(props: ChessboardProps) {
     if (item === null) {
       dataViewerController.hide();
     } else if (item.type === "card") {
-      dataViewerController.showState("card", item.info.data, [], {includesImage: item.showImage});
+      dataViewerController.showState("card", item.info.data, {
+        includesImage: item.showImage,
+      });
     } else if (item.type === "character") {
       dataViewerController.showState(
         "character",
@@ -1100,14 +1103,18 @@ export function Chessboard(props: ChessboardProps) {
         item.info.combatStatus.map((x) => x.data),
       );
     } else if (item.type === "entity") {
-      dataViewerController.showState("entity", item.info.data, []);
+      dataViewerController.showState("entity", item.info.data);
     } else if (item.type === "skill") {
       dataViewerController.showSkill(item.info.id);
     } else if (item.type === "externalCard") {
       if (typeof item.info === "number") {
-        dataViewerController.showCard(item.info, {includesImage: item.showImage});
+        dataViewerController.showCard(item.info, {
+          includesImage: item.showImage,
+        });
       } else {
-        dataViewerController.showState("card", item.info, [], {includesImage: item.showImage});
+        dataViewerController.showState("card", item.info, {
+          includesImage: item.showImage,
+        });
       }
     }
   });
@@ -1996,7 +2003,11 @@ export function Chessboard(props: ChessboardProps) {
             shown={specialViewVisible()}
             candidateIds={localProps.selectCardCandidates}
             onClickCard={(id) => {
-              setSelectingItem({ type: "externalCard", info: id, showImage: false });
+              setSelectingItem({
+                type: "externalCard",
+                info: id,
+                showImage: false,
+              });
             }}
             onConfirm={(id) => {
               localProps.onSelectCard?.(id);
@@ -2065,7 +2076,10 @@ export function Chessboard(props: ChessboardProps) {
               showOppView={hasOppSpecialView()}
             />
           </Show>
-          <div class="mx-2 my-13 pointer-events-none contain-strict touch-pan" data-dark>
+          <div
+            class="mx-2 my-13 pointer-events-none contain-strict touch-pan"
+            data-dark
+          >
             <CardDataViewer />
           </div>
           {/* 右上角部件 */}

--- a/packages/web-ui-core/src/components/Chessboard.tsx
+++ b/packages/web-ui-core/src/components/Chessboard.tsx
@@ -1058,7 +1058,6 @@ export function Chessboard(props: ChessboardProps) {
 
   const { assetsManager, locale, t } = useUiContext();
   const { CardDataViewer, ...dataViewerController } = createCardDataViewer({
-    includesImage: true,
     assetsManager,
     locale,
   });

--- a/packages/web-ui-core/src/components/Chessboard.tsx
+++ b/packages/web-ui-core/src/components/Chessboard.tsx
@@ -1061,7 +1061,7 @@ export function Chessboard(props: ChessboardProps) {
     assetsManager,
     locale,
   });
-  const [selectingItem, setSelectingItem] = createSignal<SelectingItem | null>(
+  const [selectingItem, setSelectingItem] = createSignal<SelectingItem & {showImage?: boolean} | null>(
     null,
   );
   /** 是否是主棋盘上被选中的卡 */
@@ -1092,7 +1092,7 @@ export function Chessboard(props: ChessboardProps) {
     if (item === null) {
       dataViewerController.hide();
     } else if (item.type === "card") {
-      dataViewerController.showState("card", item.info.data);
+      dataViewerController.showState("card", item.info.data, [], {includesImage: item.showImage});
     } else if (item.type === "character") {
       dataViewerController.showState(
         "character",
@@ -1100,14 +1100,14 @@ export function Chessboard(props: ChessboardProps) {
         item.info.combatStatus.map((x) => x.data),
       );
     } else if (item.type === "entity") {
-      dataViewerController.showState("eneity", item.info.data);
+      dataViewerController.showState("entity", item.info.data, []);
     } else if (item.type === "skill") {
       dataViewerController.showSkill(item.info.id);
     } else if (item.type === "externalCard") {
       if (typeof item.info === "number") {
-        dataViewerController.showCard(item.info);
+        dataViewerController.showCard(item.info, {includesImage: item.showImage});
       } else {
-        dataViewerController.showState("card", item.info);
+        dataViewerController.showState("card", item.info, [], {includesImage: item.showImage});
       }
     }
   });
@@ -1488,7 +1488,7 @@ export function Chessboard(props: ChessboardProps) {
           return c.filter((_, i) => i !== index);
         }
       });
-      setSelectingItem({ type: "card", info: cardInfo });
+      setSelectingItem({ type: "card", info: cardInfo, showImage: false });
     }
   };
 
@@ -1748,7 +1748,7 @@ export function Chessboard(props: ChessboardProps) {
   };
 
   const onMiniViewCardClick = (card: number | PbEntityState) => {
-    setSelectingItem({ type: "externalCard", info: card });
+    setSelectingItem({ type: "externalCard", info: card, showImage: true });
     setFocusingHands(false);
     setShowCardHint("myHand", null);
     setOppFocusingHands(false);
@@ -1996,7 +1996,7 @@ export function Chessboard(props: ChessboardProps) {
             shown={specialViewVisible()}
             candidateIds={localProps.selectCardCandidates}
             onClickCard={(id) => {
-              setSelectingItem({ type: "externalCard", info: id });
+              setSelectingItem({ type: "externalCard", info: id, showImage: false });
             }}
             onConfirm={(id) => {
               localProps.onSelectCard?.(id);
@@ -2065,7 +2065,7 @@ export function Chessboard(props: ChessboardProps) {
               showOppView={hasOppSpecialView()}
             />
           </Show>
-          <div class="mx-2 my-13 pointer-events-none contain-strict touch-pan card-data-viewer">
+          <div class="mx-2 my-13 pointer-events-none contain-strict touch-pan" data-dark>
             <CardDataViewer />
           </div>
           {/* 右上角部件 */}

--- a/packages/web-ui-core/src/style.css
+++ b/packages/web-ui-core/src/style.css
@@ -730,10 +730,8 @@
   }
 
   /* CardDataViewer */
-  .card-data-viewer .gi-tcg-card-data-viewer {
-    height: 147%;
-    transform: scale(0.68);
-    transform-origin: top left;
+  .gi-tcg-card-data-viewer {
+    font-size: 0.68rem;
   }
 
   /* Merge Chessboard */


### PR DESCRIPTION
- 布局改为由fontsize控制大小，可覆写自定义属性修改行宽和颜色风格
- 将是否展示卡图从createOpt改为showOpt
- 增加实体分组合并按键，在分类查看的基础上提供按入场顺序查看的可能
- 重构小部分解析逻辑，区分主选实体和附属实体
