### PR TITLE
fix(typings, core, web-ui): No-op changePhase should be silent

### DIFF
--- a/packages/core/src/base/mutation.ts
+++ b/packages/core/src/base/mutation.ts
@@ -66,6 +66,7 @@ export interface StepIdM {
 
 export interface ChangePhaseM {
   readonly type: "changePhase";
+  hasChange: boolean;
   readonly newPhase: PhaseType;
 }
 
@@ -288,6 +289,7 @@ function doMutation(state: GameState, m: Mutation): GameState {
     case "changePhase": {
       return produce(state, (draft) => {
         draft.prevPhase = state.phase;
+        m.hasChange = draft.phase !== m.newPhase;
         draft.phase = m.newPhase;
       });
     }
@@ -642,9 +644,9 @@ export function stringifyMutation(m: Mutation): string | null {
       )}`;
     }
     case "removeRoundSkillLog": {
-      return `Remove round skill log of [character:${m.caller.definition.id}] from ${stringifyState(
-        m.caller,
-      )}`;
+      return `Remove round skill log of [character:${
+        m.caller.definition.id
+      }] from ${stringifyState(m.caller)}`;
     }
     case "mutateExtensionState": {
       return `Mutate state of extension ${m.extensionId} to ${JSON.stringify(

--- a/packages/core/src/builder/context/skill.ts
+++ b/packages/core/src/builder/context/skill.ts
@@ -402,6 +402,7 @@ export class SkillContext<Meta extends ContextMetaBase> {
       );
       this.mutate({
         type: "changePhase",
+        hasChange: true,
         newPhase: "gameEnd",
       });
       this.mutator.notify();
@@ -413,6 +414,7 @@ export class SkillContext<Meta extends ContextMetaBase> {
       );
       this.mutate({
         type: "changePhase",
+        hasChange: true,
         newPhase: "gameEnd",
       });
       this.mutate({

--- a/packages/core/src/game.ts
+++ b/packages/core/src/game.ts
@@ -419,6 +419,7 @@ export class Game {
             }
             this.mutate({
               type: "changePhase",
+              hasChange: this.state.phase !== newPhase,
               newPhase,
             });
             this.mutate({ type: "clearRemovedEntities" });
@@ -453,6 +454,7 @@ export class Game {
     if (this.state.phase !== "gameEnd") {
       this.mutate({
         type: "changePhase",
+        hasChange: true,
         newPhase: "gameEnd",
       });
       if (winner && winner !== this.state.winner) {

--- a/packages/core/src/io.ts
+++ b/packages/core/src/io.ts
@@ -277,6 +277,7 @@ export function exposeMutation(
       const newPhase = exposePhaseType(m.newPhase);
       return {
         $case: "changePhase",
+        hasChange: m.hasChange,
         newPhase,
       };
     case "stepRound":

--- a/packages/web-ui-core/src/history/parser.ts
+++ b/packages/web-ui-core/src/history/parser.ts
@@ -445,6 +445,9 @@ export function updateHistory(
       const m = flattenPbOneof(pbm.mutation!);
       switch (m.$case) {
         case "changePhase": {
+          if (!m.hasChange) {
+            continue;
+          }
           const newPhase = (
             {
               [PbPhaseType.INIT_HANDS]: "initHands",

--- a/packages/web-ui-core/src/mutations.ts
+++ b/packages/web-ui-core/src/mutations.ts
@@ -362,6 +362,7 @@ export function parseMutations(
       }
       case "changePhase": {
         if (
+          mutation.value.hasChange &&
           [PbPhaseType.ROLL, PbPhaseType.ACTION, PbPhaseType.END].includes(
             mutation.value.newPhase,
           )

--- a/proto/mutation.proto
+++ b/proto/mutation.proto
@@ -55,6 +55,7 @@ message ExposedMutation {
 
 message ChangePhaseEM {
   PhaseType new_phase = 1;
+  bool has_change = 2;
 }
 
 message StepRoundEM { }


### PR DESCRIPTION
<!--
Thank you for your contribution! To help us review your pull request more efficiently, please fill out the following sections:

- Clearly describe what you changed and why.
- Explain how you verified that your changes are correct.
-->

## What Changed

d6070b makes `changePhase` mutation always applied to update correct `prevPhase` but makes frontend noisy.

We add `hasChange` field to ProtoBuf definition indicating whether a changePhase mutation will change current phase in this PR. So that frontend can filter out the noises.

<!-- Describe the changes you made. What functionality, code, or files did you update? Why was this change necessary? -->

## How to Prove It Works

<!-- Explain how you tested your changes. Did you run unit tests, integration tests, or manual verifications? Please provide steps or evidence that demonstrate your change is correct. -->
