### PR TITLE
fix(core/gts): technique usage consuming

### DIFF
--- a/packages/core/src/gts/vm_impl/card.ts
+++ b/packages/core/src/gts/vm_impl/card.ts
@@ -355,7 +355,7 @@ export const CardViewModel = InitiativeSkillViewModel
       model.targetGetters = [techniqueModel.targetGetter];
       model.tags.push("technique");
       model.setEquipmentPlayAction();
-    }),
+    }, TechniqueViewModel),
     talent: h.attribute<{
       <Meta extends CardVMMeta>(
         this: NoTargetSpecifiedThis<Meta>,

--- a/packages/core/src/gts/vm_impl/technique.ts
+++ b/packages/core/src/gts/vm_impl/technique.ts
@@ -42,6 +42,128 @@ import { GiTcgDataError } from "../..";
 import { TechniqueNightsoulVM } from "./entity_auxilary";
 import type { DisposeEventArg } from "../../base/skill";
 
+class TechniqueSkillModel extends InitiativeSkillModel {
+  private caller: TechniqueModel;
+  override get ownerType() {
+    return "equipment" as const;
+  }
+
+  usageOpt: { name: string; autoDecrease: boolean } | null = null;
+  usagePerRoundOpt: {
+    name: UsagePerRoundVariableNames;
+    autoDecrease: boolean;
+  } | null = null;
+
+  constructor(caller: TechniqueModel) {
+    super();
+    this.caller = caller;
+    this.skillType = "technique";
+  }
+
+  setUsage(count: number, option: GtsUsageOrUsagePerRoundOptions) {
+    const perRound = option.perRound ?? false;
+    const autoDecrease = option.autoDecrease ?? true;
+    const name = this.caller.setUsage(count, option);
+    if (perRound) {
+      if (this.usagePerRoundOpt) {
+        throw new GiTcgDataError(
+          "Cannot set usage per round multiple times for the same skill.",
+        );
+      }
+      this.usagePerRoundOpt = {
+        name: name as UsagePerRoundVariableNames,
+        autoDecrease,
+      };
+    } else {
+      if (this.usageOpt) {
+        throw new GiTcgDataError(
+          "Cannot set usage multiple times for the same skill.",
+        );
+      }
+      this.usageOpt = { name, autoDecrease };
+    }
+    this.userFilters.unshift((c) => c.self.getVariable(name) > 0);
+  }
+
+  override buildSkillDefinition() {
+    // 【可用次数自动扣除】
+    if (this.usagePerRoundOpt?.autoDecrease) {
+      this.postOperations.push((c) => {
+        c.consumeUsagePerRound();
+      });
+    }
+    if (this.usageOpt?.autoDecrease) {
+      if (this.usageOpt.name === "usage") {
+        // 若变量名为 usage，则消耗可用次数时可能调用 c.dispose
+        // 使用 consumeUsage 方法实现相关操作
+        this.postOperations.push((c) => {
+          c.consumeUsage();
+        });
+      } else {
+        // 否则手动扣除使用次数
+        const name = this.usageOpt.name;
+        this.postOperations.push((c) => {
+          c.self.addVariable(name, -1);
+        });
+      }
+    }
+    return super.buildSkillDefinition();
+  }
+}
+
+interface TechniqueSkillVMMeta extends InitiativeSkillVMMeta {
+  variables: string;
+}
+const DEFAULT_TECHNIQUE_SKILL_VM_META = {
+  ...DEFAULT_INITIATIVE_SKILL_VM_META,
+  type: "equipment",
+  variables: null as never,
+} as const satisfies TechniqueSkillVMMeta;
+
+export const TechniqueSkillViewModel = InitiativeSkillViewModel
+  //
+  .extend(TechniqueSkillModel, (h) => ({
+    id: h.attribute<{
+      (id: number): AR.Done;
+      required(): true;
+      uniqueKey(): "id";
+      as(): SkillHandle;
+    }>(
+      (model, [id]) => {
+        model.id = id;
+      },
+      (_, [id]) => id as any,
+    ),
+    usage: h.attribute<{
+      <Meta extends TechniqueSkillVMMeta>(
+        this: AR.This<Meta>,
+        count: number,
+      ): AR.With<typeof UsageVM>;
+      <Meta extends TechniqueSkillVMMeta>(
+        this: AR.This<Meta>,
+        perRound: "perRound",
+        count: number,
+      ): AR.With<typeof UsageVM, { name: "usagePerRound" }>;
+      mergeMeta<
+        Meta extends TechniqueSkillVMMeta,
+        InnerMeta extends UsageVMMeta,
+      >(
+        meta: Meta,
+        innerMeta: InnerMeta,
+      ): Omit<Meta, "variables"> & {
+        variables: Meta["variables"] | InnerMeta["name"];
+      };
+    }>((model, positionals, subView) => {
+      const options = UsageVM.parse(subView);
+      if (positionals[0] === "perRound") {
+        model.setUsage(positionals[1], { ...options, perRound: true });
+      } else {
+        model.setUsage(positionals[0], { ...options, perRound: false });
+      }
+    }),
+  }))
+  .bind<typeof DEFAULT_TECHNIQUE_SKILL_VM_META>();
+
 export class TechniqueModel extends EntityModel {
   constructor(id?: number) {
     super("equipment", id);
@@ -146,103 +268,6 @@ export const TechniqueViewModel = EntityViewModel
       const skillModel = TechniqueSkillViewModel.parse(subView, model);
       const skillDef = skillModel.buildSkillDefinition();
       model.skillList.push(skillDef);
-    }),
+    }, TechniqueSkillViewModel.bind(null!)),
   }))
   .bind<TechniqueVMMeta>();
-
-class TechniqueSkillModel extends InitiativeSkillModel {
-  private caller: TechniqueModel;
-  override get ownerType() {
-    return "equipment" as const;
-  }
-
-  usageOpt: { name: string; autoDecrease: boolean } | null = null;
-  usagePerRoundOpt: {
-    name: UsagePerRoundVariableNames;
-    autoDecrease: boolean;
-  } | null = null;
-
-  constructor(caller: TechniqueModel) {
-    super();
-    this.caller = caller;
-    this.skillType = "technique";
-  }
-
-  setUsage(count: number, option: GtsUsageOrUsagePerRoundOptions) {
-    const perRound = option.perRound ?? false;
-    const autoDecrease = option.autoDecrease ?? true;
-    const name = this.caller.setUsage(count, option);
-    if (perRound) {
-      if (this.usagePerRoundOpt) {
-        throw new GiTcgDataError(
-          "Cannot set usage per round multiple times for the same skill.",
-        );
-      }
-      this.usagePerRoundOpt = {
-        name: name as UsagePerRoundVariableNames,
-        autoDecrease,
-      };
-    } else {
-      if (this.usageOpt) {
-        throw new GiTcgDataError(
-          "Cannot set usage multiple times for the same skill.",
-        );
-      }
-      this.usageOpt = { name, autoDecrease };
-    }
-    this.userFilters.unshift((c) => c.self.getVariable(name) > 0);
-  }
-}
-
-interface TechniqueSkillVMMeta extends InitiativeSkillVMMeta {
-  variables: string;
-}
-const DEFAULT_TECHNIQUE_SKILL_VM_META = {
-  ...DEFAULT_INITIATIVE_SKILL_VM_META,
-  type: "equipment",
-  variables: null as never,
-} as const satisfies TechniqueSkillVMMeta;
-
-export const TechniqueSkillViewModel = InitiativeSkillViewModel
-  //
-  .extend(TechniqueSkillModel, (h) => ({
-    id: h.attribute<{
-      (id: number): AR.Done;
-      required(): true;
-      uniqueKey(): "id";
-      as(): SkillHandle;
-    }>(
-      (model, [id]) => {
-        model.id = id;
-      },
-      (_, [id]) => id as any,
-    ),
-    usage: h.attribute<{
-      <Meta extends TechniqueSkillVMMeta>(
-        this: AR.This<Meta>,
-        count: number,
-      ): AR.With<typeof UsageVM>;
-      <Meta extends TechniqueSkillVMMeta>(
-        this: AR.This<Meta>,
-        perRound: "perRound",
-        count: number,
-      ): AR.With<typeof UsageVM, { name: "usagePerRound" }>;
-      mergeMeta<
-        Meta extends TechniqueSkillVMMeta,
-        InnerMeta extends UsageVMMeta,
-      >(
-        meta: Meta,
-        innerMeta: InnerMeta,
-      ): Omit<Meta, "variables"> & {
-        variables: Meta["variables"] | InnerMeta["name"];
-      };
-    }>((model, positionals, subView) => {
-      const options = UsageVM.parse(subView);
-      if (positionals[0] === "perRound") {
-        model.setUsage(positionals[1], { ...options, perRound: true });
-      } else {
-        model.setUsage(positionals[0], { ...options, perRound: false });
-      }
-    }),
-  }))
-  .bind<typeof DEFAULT_TECHNIQUE_SKILL_VM_META>();

--- a/packages/test/__tests__/mavuika.test.tsx
+++ b/packages/test/__tests__/mavuika.test.tsx
@@ -13,10 +13,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { ref, setup, Character, State, Equipment, Card, $ } from "#test";
-import { LumenstoneAdjuvant } from "@gi-tcg/data/internal/cards/support/item.gts";
+import { ref, setup, Character, State, Card, $ } from "#test";
 import { ScionsOfTheCanopy } from "@gi-tcg/data/internal/cards/support/place.gts";
-import { FlamestriderBlazingTrail, Mavuika, TheNamedMoment } from "@gi-tcg/data/internal/characters/pyro/mavuika.gts";
+import {
+  BlazingTrail,
+  FlamestriderBlazingTrail,
+  Mavuika,
+  TheNamedMoment,
+} from "@gi-tcg/data/internal/characters/pyro/mavuika.gts";
 import { expect, test } from "vitest";
 
 test("mavuika: play 'E' card trigger ScionsOfTheCanopy", async () => {
@@ -38,4 +42,10 @@ test("mavuika: play 'E' card trigger ScionsOfTheCanopy", async () => {
   });
   // 8 - 3(火神E) - 2(涉渡) + 1(悬木人生成) = 4
   expect(c.state.players[0].dice).toBeArrayOfSize(4);
+  // 点涉渡
+  await c.me.skill(BlazingTrail);
+  c.expect($.my.prev).toBeDefinition(Mavuika);
+  c.expect($.my.typeEquipment.def(FlamestriderBlazingTrail)).toHaveVariable({
+    usage: 1,
+  });
 });


### PR DESCRIPTION
<!--
Thank you for your contribution! To help us review your pull request more efficiently, please fill out the following sections:

- Clearly describe what you changed and why.
- Explain how you verified that your changes are correct.
-->

## What Changed

1. `usageOpt` and `usagePerRoundOpt` should be translated to `postOperations` in `TechinqueSkillModel#buildSkillDefinition`.
2. Add test for that.
3. Technique Skill ID should be bounded; passing through VM are configured in binding context.

<!-- Describe the changes you made. What functionality, code, or files did you update? Why was this change necessary? -->

## How to Prove It Works

We have test.

<!-- Explain how you tested your changes. Did you run unit tests, integration tests, or manual verifications? Please provide steps or evidence that demonstrate your change is correct. -->
