### PR TITLE
fix(core/context): remove trapping SkillContext.

### DIFF
--- a/packages/core/src/builder/context/skill.ts
+++ b/packages/core/src/builder/context/skill.ts
@@ -818,16 +818,10 @@ export class SkillContext<Meta extends ContextMetaBase> {
     if (!snippet) {
       throw new GiTcgDataError(`Snippet ${name} not found`);
     }
-    const { proxy, revoke } = Proxy.revocable(this, {
-      get(target, prop, receiver) {
-        if (prop === "eventArg") {
-          return arg;
-        }
-        return Reflect.get(target, prop, receiver);
-      },
-    });
-    snippet(proxy);
-    revoke();
+    const previousEventArg = this.eventArg;
+    Reflect.set(this, "eventArg", arg);
+    snippet(this);
+    Reflect.set(this, "eventArg", previousEventArg);
   }
 
   switchActive(target: CharacterTargetArg) {


### PR DESCRIPTION
A reactive state produced by a SkillContext instance will record a proxied version as its member in previous implementation. If the reactive state was reused from cache later, the proxy have been revoked immediately after snippet calling.