### PR TITLE
fix(web-ui/history): add boundary for history updating

### DIFF
--- a/packages/web-ui-core/src/components/HistoryViewer.tsx
+++ b/packages/web-ui-core/src/components/HistoryViewer.tsx
@@ -1764,7 +1764,9 @@ function HistoryBlockItem(props: {
   });
 
   const detailData = createMemo(() => {
-    if (isHint(props.block)) return null;
+    if (isHint(props.block) || props.block.type === "boundary") {
+      return null;
+    }
     return renderHistoryBlock(props.block);
   });
 
@@ -1780,7 +1782,7 @@ function HistoryBlockItem(props: {
           onClick={() => props.onSelect(props.block)}
         />
       </Match>
-      <Match when={true}>
+      <Match when={props.block.type !== "boundary"}>
         <HistoryBlockBox
           data={detailData() as HistoryBlockData}
           isSelected={props.isSelected}

--- a/packages/web-ui-core/src/history/parser.ts
+++ b/packages/web-ui-core/src/history/parser.ts
@@ -52,10 +52,8 @@ import type {
   HistoryChildren,
   HistoryDetailBlock,
   IncreaseMaxHealthHistoryChild,
-  UseSkillHistoryBlock,
   VariableChangeHistoryChild,
 } from "./typings";
-import { flip } from "@gi-tcg/utils";
 
 export interface HistoryData {
   blocks: HistoryBlock[];
@@ -327,14 +325,12 @@ export class StateRecorder {
         return Map.groupBy(generated, (i) => i)
           .entries()
           .toArray()
-          .map(
-            ([d, arr]): GenerateDiceHistoryChild => ({
-              type: "generateDice",
-              who: mut.who as 0 | 1,
-              diceType: d,
-              count: arr.length,
-            }),
-          );
+          .map(([d, arr]): GenerateDiceHistoryChild => ({
+            type: "generateDice",
+            who: mut.who as 0 | 1,
+            diceType: d,
+            count: arr.length,
+          }));
       }
       case PbResetDiceReason.ABSORB: {
         const diceCount = old.length - new_.length;
@@ -421,7 +417,7 @@ export function updateHistory(
 ) {
   try {
     const lastMainBlock = history.blocks.at(-1);
-    const lastHintBlock = history.blocks.findLast((b) => !("children" in b));
+    const lastActionBlock = history.blocks.findLast((b) => b.type === "action");
 
     let roundNumber = previousState?.roundNumber ?? 0;
     let phase = previousState?.phase ?? PbPhaseType.ACTION;
@@ -445,7 +441,11 @@ export function updateHistory(
       const m = flattenPbOneof(pbm.mutation!);
       switch (m.$case) {
         case "changePhase": {
+          console.log(m);
           if (!m.hasChange) {
+            history.blocks.push({
+              type: "boundary",
+            });
             continue;
           }
           const newPhase = (
@@ -848,8 +848,7 @@ export function updateHistory(
         }
         case "playerStatusChange": {
           if (m.status === PbPlayerStatus.ACTING) {
-            const skip =
-              lastHintBlock?.type === "action" && lastHintBlock.who === m.who;
+            const skip = lastActionBlock?.who === m.who;
             if (!skip) {
               history.blocks.push({
                 type: "action",

--- a/packages/web-ui-core/src/history/typings.ts
+++ b/packages/web-ui-core/src/history/typings.ts
@@ -27,7 +27,8 @@ export type HistoryDetailBlock =
 
 export type HistoryHintBlock = ChangePhaseHistoryBlock | ActionHistoryBlock;
 
-export type HistoryBlock = HistoryDetailBlock | HistoryHintBlock;
+export type HistoryBlock =
+  HistoryDetailBlock | HistoryHintBlock | BoundaryHistoryBlock;
 
 export type HistoryChildren =
   | SwitchActiveHistoryChild
@@ -96,6 +97,11 @@ export interface PocketHistoryBlock {
   type: "pocket";
   indent: number;
   children: HistoryChildren[];
+}
+
+// 不渲染，用来分隔 parser 的修改边界
+export interface BoundaryHistoryBlock {
+  type: "boundary";
 }
 
 // 切换出战角色


### PR DESCRIPTION
<!--
Thank you for your contribution! To help us review your pull request more efficiently, please fill out the following sections:

- Clearly describe what you changed and why.
- Explain how you verified that your changes are correct.
-->

## What Changed

Prevent inserting children block across phase boundary, typically consuming energy.

<!-- Describe the changes you made. What functionality, code, or files did you update? Why was this change necessary? -->

## How to Prove It Works

<!-- Explain how you tested your changes. Did you run unit tests, integration tests, or manual verifications? Please provide steps or evidence that demonstrate your change is correct. -->
