### PR TITLE
fix(server): set active rooms after room started

### DIFF
--- a/packages/server/src/rooms/rooms.service.ts
+++ b/packages/server/src/rooms/rooms.service.ts
@@ -974,10 +974,6 @@ export class RoomsService {
         1,
         String(room.id),
       );
-      // If the room already stopped before we finished updating Redis, avoid leaving a stale entry.
-      if (room.status === RoomStatus.Finished) {
-        await redis?.hdel("meta:active_rooms", String(room.id));
-      }
     } catch (e) {
       this.logger.warn(
         `Failed to update meta:active_rooms for room ${room.id}: ${e}`,

--- a/packages/server/src/rooms/rooms.service.ts
+++ b/packages/server/src/rooms/rooms.service.ts
@@ -792,14 +792,6 @@ export class RoomsService {
       throw new InternalServerErrorException("no room available");
     }
     const room = new Room(roomId, roomConfig);
-    await redis?.hset("meta:active_rooms", roomId, JSON.stringify(roomConfig));
-    await redis?.hexpire(
-      "meta:active_rooms",
-      1 * 60 * 60,
-      "FIELDS",
-      1,
-      String(roomId),
-    );
     this.rooms.set(roomId, room);
     this.roomIdPool.shift();
     this.metrics.incrementCreatedRooms();
@@ -969,6 +961,14 @@ export class RoomsService {
       });
     });
     room.start();
+    await redis?.hset("meta:active_rooms", roomId, JSON.stringify(room.config));
+    await redis?.hexpire(
+      "meta:active_rooms",
+      1 * 60 * 60,
+      "FIELDS",
+      1,
+      String(room.id),
+    );
     this.metrics.incrementStartedRooms();
   }
 

--- a/packages/server/src/rooms/rooms.service.ts
+++ b/packages/server/src/rooms/rooms.service.ts
@@ -961,14 +961,28 @@ export class RoomsService {
       });
     });
     room.start();
-    await redis?.hset("meta:active_rooms", roomId, JSON.stringify(room.config));
-    await redis?.hexpire(
-      "meta:active_rooms",
-      1 * 60 * 60,
-      "FIELDS",
-      1,
-      String(room.id),
-    );
+    try {
+      await redis?.hset(
+        "meta:active_rooms",
+        String(room.id),
+        JSON.stringify(room.config),
+      );
+      await redis?.hexpire(
+        "meta:active_rooms",
+        1 * 60 * 60,
+        "FIELDS",
+        1,
+        String(room.id),
+      );
+      // If the room already stopped before we finished updating Redis, avoid leaving a stale entry.
+      if (room.status === RoomStatus.Finished) {
+        await redis?.hdel("meta:active_rooms", String(room.id));
+      }
+    } catch (e) {
+      this.logger.warn(
+        `Failed to update meta:active_rooms for room ${room.id}: ${e}`,
+      );
+    }
     this.metrics.incrementStartedRooms();
   }
 

--- a/packages/server/src/rooms/rooms.service.ts
+++ b/packages/server/src/rooms/rooms.service.ts
@@ -964,7 +964,7 @@ export class RoomsService {
     try {
       await redis?.hset(
         "meta:active_rooms",
-        String(room.id),
+        String(roomId),
         JSON.stringify(room.config),
       );
       await redis?.hexpire(
@@ -972,7 +972,7 @@ export class RoomsService {
         1 * 60 * 60,
         "FIELDS",
         1,
-        String(room.id),
+        String(roomId),
       );
     } catch (e) {
       this.logger.warn(


### PR DESCRIPTION
# The Problem

<img width="2896" height="659" alt="image" src="https://github.com/user-attachments/assets/d1670604-193b-4961-a8f2-2f4e268ad572" />

# How Do This PR Fix

Move the active room setting after room started, so creating rooms but not playing will not blocked new deployments.