### PR TITLE
fix(core, data): Play or onEnter? (Phase I)

### DIFF
--- a/docs/development/data/card.md
+++ b/docs/development/data/card.md
@@ -57,9 +57,10 @@ define card {
   id 212091 as TurnControl;
   cost DiceType.Hydro, 3;
   talent Yelan {
-    on enter {
-      :useSkill(LingeringLifeline);
-    };
+    on staged,
+      :{
+        :useSkill(LingeringLifeline);
+      };
     on roll {
       :e.fixDice(DiceType.Omni, 1);
     };
@@ -76,6 +77,8 @@ define card {
   };
 };
 ```
+
+支援和装备的打出时效果使用 `on staged, :{ ... };`。该操作会在牌移动到支援区或装备到角色后立即执行，并可通过 `:e` 访问本次出牌的目标。它只随打出该牌执行；通过其他效果直接创建支援或装备时不会执行。支援和装备不能定义 `on enter`，其他实体仍可使用 `on enter` 响应入场事件。
 
 - `weapon <武器标签> { ... }`：装备给对应武器类型的角色；
 - `artifact { ... }`：装备给我方角色；

--- a/docs/development/data/card.md
+++ b/docs/development/data/card.md
@@ -57,10 +57,9 @@ define card {
   id 212091 as TurnControl;
   cost DiceType.Hydro, 3;
   talent Yelan {
-    on staged,
-      :{
-        :useSkill(LingeringLifeline);
-      };
+    on staged {
+      :useSkill(LingeringLifeline);
+    };
     on roll {
       :e.fixDice(DiceType.Omni, 1);
     };
@@ -78,7 +77,7 @@ define card {
 };
 ```
 
-支援和装备的打出时效果使用 `on staged, :{ ... };`。该操作会在牌移动到支援区或装备到角色后立即执行，并可通过 `:e` 访问本次出牌的目标。它只随打出该牌执行；通过其他效果直接创建支援或装备时不会执行。支援和装备不能定义 `on enter`，其他实体仍可使用 `on enter` 响应入场事件。
+支援和装备的打出时效果使用 `on staged { ... };`。该操作会在牌移动到支援区或装备到角色后立即执行，并可通过 `:e` 访问本次出牌的目标。它只随打出该牌执行；通过其他效果直接创建支援或装备时不会执行。支援和装备不能定义 `on enter`，其他实体仍可使用 `on enter` 响应入场事件。
 
 - `weapon <武器标签> { ... }`：装备给对应武器类型的角色；
 - `artifact { ... }`：装备给我方角色；

--- a/docs/development/data/entity.md
+++ b/docs/development/data/entity.md
@@ -87,7 +87,7 @@ define combatStatus {
 define status {
   id 127011 as RadicalVitalityStatus;
   variable vitality, 0;
-  defineSnippet addVitality, :{
+  defineSnippet addVitality {
     :addVariableWithMax("vitality", 1, 3);
   };
   on dealDamage {

--- a/docs/development/data/events.md
+++ b/docs/development/data/events.md
@@ -20,7 +20,7 @@ define combatStatus {
 | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 阶段             | `onBattleBegin`、`onRoundBegin`、`onRoundEnd`、`onActionPhase`、`onEndPhase`                                                                                                     |
 | 行动             | `replaceAction`、`onBeforeAction`、`onAction`、`onBeforeUseSkill`、`onUseSkill`、`onBeforePlayCard`、`onPlayCard`、`onSwitchActive`                                              |
-| 牌与实体         | `onHandCardInserted`、`onEnter`、`onDispose`、`onSelectCard`、`onTransformDefinition`、`onGenerateDice`                                                                          |
+| 牌与实体         | `onHandCardInserted`、`onEnter`、`onDispose`、`onSelectCard`、`onAdventure`、`onTransformDefinition`、`onGenerateDice`                                                           |
 | 伤害、治疗与反应 | `onDamageOrHeal`、`onReaction`、`onRevive`                                                                                                                                       |
 | 可修改的效果     | `modifyRoll`、`modifyAction0` 至 `modifyAction4`、`modifyDamage0` 至 `modifyDamage3`、`modifyHeal0`、`modifyHeal1`、`modifyReaction`、`modifyChangeVariable`、`modifyZeroHealth` |
 | 自定义           | `onCustomEvent`                                                                                                                                                                  |
@@ -53,7 +53,8 @@ define combatStatus {
 | `disposeCard`、`disposeOrTuneCard`、`selfDiscard`、`dispose`、`selfDispose`                                      | `onDispose`                    | 弃牌、调和、实体离场       |
 | `dealDamage`、`skillDamage`、`damaged`、`healed`、`damagedOrHealed`、`defeated`                                  | `onDamageOrHeal`               | 伤害、治疗和倒下           |
 | `reaction`、`dealReaction`、`modifyReaction`                                                                     | `onReaction`、`modifyReaction` | 元素反应                   |
-| `enter`、`enterRelative`、`adventure`                                                                            | `onEnter`                      | 自身或相关实体入场         |
+| `enter`、`enterRelative`                                                                                         | `onEnter`                      | 自身或相关实体入场         |
+| `adventure`                                                                                                      | `onAdventure`                  | 自身进行冒险               |
 | `revive`、`transformDefinition`、`generateDice`、`selectCard`                                                    | 对应同名核心事件               | 复苏、变身、生成骰子、选牌 |
 | `cancelConsumeNightsoul`、`consumeNightsoul`、`gainNightsoul`、`gainUsage`                                       | 变量修改事件                   | 夜魂值或可用次数           |
 

--- a/docs/development/data/extensions.md
+++ b/docs/development/data/extensions.md
@@ -36,13 +36,12 @@ define card {
   support ally {
     associateExtension DisposedSupportCountExtension;
     variable experience, 0;
-    on staged,
-      :{
-        :setVariable(
-          "experience",
-          Math.min(:getExtensionState().disposedSupportCount[:self.who], 6),
-        );
-      };
+    on staged {
+      :setVariable(
+        "experience",
+        Math.min(:getExtensionState().disposedSupportCount[:self.who], 6),
+      );
+    };
   };
 };
 ```

--- a/docs/development/data/extensions.md
+++ b/docs/development/data/extensions.md
@@ -36,14 +36,15 @@ define card {
   support ally {
     associateExtension DisposedSupportCountExtension;
     variable experience, 0;
-    on enter {
-      :setVariable(
-        "experience",
-        Math.min(:getExtensionState().disposedSupportCount[:self.who], 6),
-      );
-    };
+    on staged,
+      :{
+        :setVariable(
+          "experience",
+          Math.min(:getExtensionState().disposedSupportCount[:self.who], 6),
+        );
+      };
   };
 };
 ```
 
-`associateExtension` 只提供对该扩展点的上下文访问权限；它不会自动同步实体变量。需要同步时，在 `on enter`、相关事件或操作中显式读取并写入。
+`associateExtension` 只提供对该扩展点的上下文访问权限；它不会自动同步实体变量。需要同步时，在 `on staged`、相关事件或操作中显式读取并写入。

--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -60,7 +60,8 @@ StateMutator 通知前端、请求 Player IO、记录 Mutation 与详细日志
 
 - 对普通核心事件：先收集该事件的所有监听技能，再按 `allSkills` 的当前实体顺序逐一检查 filter 并结算。`onDispose` 会额外让刚被弃置的实体自身响应。
 - 对 `requestReroll`、`requestSwitchHands`、`requestSelectCard`：调用相应 Player IO，再立即递归处理操作产生的事件；选牌完成后额外触发 `onSelectCard`。
-- 对 `requestUseSkill`、`requestPlayCard`、`requestAdventure`、`requestTriggerEndPhaseSkill`：验证当前可用对象后执行相应技能或实体操作，再递归处理其事件。
+- 对 `requestUseSkill`、`requestPlayCard`、`requestTriggerEndPhaseSkill`：验证当前可用对象后执行相应技能或实体操作，再递归处理其事件。
+- 对 `requestAdventure`：若已有冒险地点则增加其 `exp`，否则在有空位时请求选择冒险地点；随后触发该地点的 `onAdventure`，若发生过选牌则最后触发 `onSelectCard`。
 
 监听技能的收集包括扩展点和当前场上的实体，不包括 `removedEntities`。扩展点以当前行动方的出战角色作为 caller；实体的默认监听范围和细分事件过滤由数据定义层完成，参见[事件](./data/events.md)。
 

--- a/packages/core/src/base/skill.ts
+++ b/packages/core/src/base/skill.ts
@@ -1383,6 +1383,7 @@ export const EVENT_MAP = {
   onChangeVariable: VariableEventArg,
 
   onSelectCard: SelectCardEventArg,
+  onAdventure: EntityEventArg,
 
   modifyDamage0: ModifyDamage0EventArg, // 类型
   modifyDamage1: ModifyDamage1EventArg, // 加

--- a/packages/core/src/gts/vm_impl/card.ts
+++ b/packages/core/src/gts/vm_impl/card.ts
@@ -39,11 +39,7 @@ import {
   type ICaller,
   type ThisWithType,
 } from "./entity";
-import type {
-  CharacterHandle,
-  HandleT,
-  StatusHandle,
-} from "../../data/type";
+import type { CharacterHandle, HandleT, StatusHandle } from "../../data/type";
 import type { TalentRequirement } from "../../runtime/card";
 import type {
   DetailedEventArgOf,
@@ -100,7 +96,7 @@ export class CardModel extends InitiativeSkillModel implements ICaller {
   descriptionDictionary: Writable<DescriptionDictionary> = {};
 
   public get snippets() {
-    return super.snippets;
+    return this.innerModel?.snippets ?? super.snippets;
   }
 
   type: "support" | "equipment" | "eventCard" = "eventCard";
@@ -128,13 +124,18 @@ export class CardModel extends InitiativeSkillModel implements ICaller {
   }
 
   setEquipmentPlayAction(): void {
+    const stagedOperations = this.innerModel?.stagedOperations ?? [];
     this.action = function (c) {
       for (const ch of c.eventArg.targets) {
         ch.equip(c.self);
       }
+      for (const operation of stagedOperations) {
+        operation(c);
+      }
     };
   }
   setSupportPlayAction(): void {
+    const stagedOperations = this.innerModel?.stagedOperations ?? [];
     this.action = function (c) {
       // 支援牌的目标是要弃置的支援区卡牌
       const [target] = c.eventArg.targets;
@@ -149,6 +150,9 @@ export class CardModel extends InitiativeSkillModel implements ICaller {
         { who: c.self.who, type: "supports" },
         "createSupport",
       );
+      for (const operation of stagedOperations) {
+        operation(c);
+      }
     };
   }
 

--- a/packages/core/src/gts/vm_impl/entity.ts
+++ b/packages/core/src/gts/vm_impl/entity.ts
@@ -31,6 +31,7 @@ import type {
   DamageInfo,
   DamageOrHealEventArg,
   EnterEventArg,
+  InitiativeSkillEventArg,
   ModifyDamage3EventArg,
   SkillDefinition,
 } from "../../base/skill";
@@ -39,7 +40,6 @@ import {
   ListenTo,
   type DetailedEventArgOf,
   type DetailedEventNames,
-  type SkillOperation,
   type WritableMetaOf,
 } from "../../runtime/skill";
 import {
@@ -148,6 +148,7 @@ export class EntityModel implements ICaller {
   hintText: string | null = null;
   descriptionDictionary: Writable<DescriptionDictionary> = {};
   snippets = new Map<string, SnippetOperation<any, any>>();
+  stagedOperations: StagedOperation<any>[] = [];
 
   constructor(type: ExEntityType, parent?: IParentModel) {
     if (parent) {
@@ -434,6 +435,11 @@ type SnippetOperation<Meta extends EntityVMMeta, ArgT> = (
     }>
   >,
 ) => void;
+
+type StagedOperation<Meta extends EntityVMMeta> = SnippetOperation<
+  Meta,
+  InitiativeSkillEventArg
+>;
 
 export type ThisWithType<
   Meta extends EntityVMMeta,
@@ -902,6 +908,11 @@ export class EntityViewModel extends defineViewModel(
     }),
 
     on: h.attribute<{
+      <Meta extends EntityVMMeta>(
+        this: AR.This<Meta>,
+        eventName: "staged",
+        operation: StagedOperation<Meta>,
+      ): AR.Done;
       <Meta extends EntityVMMeta, const Event extends DetailedEventNames>(
         this: AR.This<Meta>,
         eventName: Event,
@@ -931,7 +942,24 @@ export class EntityViewModel extends defineViewModel(
       ): Omit<Meta, "variables"> & {
         variables: Meta["variables"] | InnerMeta["variables"];
       };
-    }>((model, [eventName], subView) => {
+    }>((model, [eventName, operation], subView) => {
+      if (eventName === "staged") {
+        if (model.type !== "support" && model.type !== "equipment") {
+          throw new GiTcgDataError(
+            "`on staged` is only available for support and equipment.",
+          );
+        }
+        model.stagedOperations.push(operation);
+        return;
+      }
+      if (
+        eventName === "enter" &&
+        (model.type === "support" || model.type === "equipment")
+      ) {
+        throw new GiTcgDataError(
+          "Support and equipment cannot define `on enter`; use `on staged, :{ ... };` instead.",
+        );
+      }
       const skillModel = TriggeredSkillViewModel.parse(
         subView,
         model,

--- a/packages/core/src/gts/vm_impl/entity.ts
+++ b/packages/core/src/gts/vm_impl/entity.ts
@@ -463,6 +463,13 @@ class StagedOperationVM extends defineActionViewModel<
   ) => AR.Done
 >() {}
 
+class SnippetOperationVM extends defineActionViewModel<
+  <Meta extends EntityVMMeta>(
+    this: AR.This<Meta>,
+    operation: SnippetOperation<Meta, void>,
+  ) => AR.Done
+>() {}
+
 export class EntityViewModel extends defineViewModel(
   EntityModel,
   (h) => ({
@@ -525,67 +532,67 @@ export class EntityViewModel extends defineViewModel(
     defineSnippet: h.attribute<{
       <Meta extends EntityVMMeta>(
         this: AR.This<Meta>,
-        operation: SnippetOperation<Meta, void>,
-      ): AR.DoneRewriteMeta<
+      ): AR.WithRewriteMeta<
         Computed<
           Omit<Meta, "snippets"> & {
             snippets: Meta["snippets"] & { default: void };
           }
-        >
+        >,
+        SnippetOperationVM,
+        Meta
       >;
       <Meta extends EntityVMMeta, const Name extends string>(
         this: AR.This<Meta>,
         name: Name,
-        operation: SnippetOperation<Meta, void>,
-      ): AR.DoneRewriteMeta<
+      ): AR.WithRewriteMeta<
         Computed<
           Omit<Meta, "snippets"> & {
             snippets: Meta["snippets"] & { [K in Name]: void };
           }
-        >
+        >,
+        SnippetOperationVM,
+        Meta
       >;
       <Meta extends EntityVMMeta, ArgT>(
         this: AR.This<Meta>,
         typeHint: TypeHint<ArgT>,
-        operation: SnippetOperation<Meta, ArgT>,
-      ): AR.DoneRewriteMeta<
+      ): AR.WithRewriteMeta<
         Computed<
           Omit<Meta, "snippets"> & {
             snippets: Meta["snippets"] & { default: ArgT };
           }
-        >
+        >,
+        SnippetOperationVM,
+        Meta
       >;
       <Meta extends EntityVMMeta, const Name extends string, ArgT>(
         this: AR.This<Meta>,
         name: Name,
         typeHint: TypeHint<ArgT>,
-        operation: SnippetOperation<Meta, ArgT>,
-      ): AR.DoneRewriteMeta<
+      ): AR.WithRewriteMeta<
         Computed<
           Omit<Meta, "snippets"> & {
             snippets: Meta["snippets"] & { [K in Name]: ArgT };
           }
-        >
+        >,
+        SnippetOperationVM,
+        Meta
       >;
-    }>((model, args) => {
+    }>((model, args, subView) => {
       let name: string;
-      let operation: SnippetOperation<any, any>;
-      if (args.length === 1) {
+      if (args.length === 0) {
         name = "default";
-        operation = args[0];
-      } else if (args.length === 2) {
+      } else if (args.length === 1) {
         if (typeof args[0] === "string") {
           name = args[0];
-          operation = args[1];
         } else {
           name = "default";
-          operation = args[1];
         }
       } else {
         name = args[0];
-        operation = args[2];
       }
-      model.snippets.set(name, operation);
+      const snippetModel = SnippetOperationVM.parse(subView);
+      model.snippets.set(name, snippetModel.action);
     }),
 
     prepare: h.attribute<{
@@ -969,7 +976,7 @@ export class EntityViewModel extends defineViewModel(
       }
       if (
         eventName === "enter" &&
-        !(["status", "combatStatus", "summon"].includes(model.type))
+        !["status", "combatStatus", "summon"].includes(model.type)
       ) {
         throw new GiTcgDataError(
           "Only status, combatStatus, and summon can have `enter` handling. For support and equipment, use `on staged { ... };` instead.",

--- a/packages/core/src/gts/vm_impl/entity.ts
+++ b/packages/core/src/gts/vm_impl/entity.ts
@@ -13,7 +13,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { defineViewModel, type AR } from "@gi-tcg/gts-runtime";
+import {
+  defineViewModel,
+  defineActionViewModel,
+  type AR,
+} from "@gi-tcg/gts-runtime";
 import * as R from "remeda";
 import {
   USAGE_PER_ROUND_VARIABLE_NAMES,
@@ -451,6 +455,13 @@ type PushVar<Meta extends EntityVMMeta, Name extends string> = Computed<
     variables: Meta["variables"] | Name;
   }
 >;
+
+class StagedOperationVM extends defineActionViewModel<
+  <Meta extends EntityVMMeta>(
+    this: AR.This<Meta>,
+    operation: StagedOperation<Meta>,
+  ) => AR.Done
+>() {}
 
 export class EntityViewModel extends defineViewModel(
   EntityModel,
@@ -911,8 +922,7 @@ export class EntityViewModel extends defineViewModel(
       <Meta extends EntityVMMeta>(
         this: AR.This<Meta>,
         eventName: "staged",
-        operation: StagedOperation<Meta>,
-      ): AR.Done;
+      ): AR.With<StagedOperationVM, Meta>;
       <Meta extends EntityVMMeta, const Event extends DetailedEventNames>(
         this: AR.This<Meta>,
         eventName: Event,
@@ -942,22 +952,27 @@ export class EntityViewModel extends defineViewModel(
       ): Omit<Meta, "variables"> & {
         variables: Meta["variables"] | InnerMeta["variables"];
       };
-    }>((model, [eventName, operation], subView) => {
+      mergeMeta<Meta extends EntityVMMeta>(
+        meta: Meta,
+        innerMeta: unknown,
+      ): Meta;
+    }>((model, [eventName], subView) => {
       if (eventName === "staged") {
         if (model.type !== "support" && model.type !== "equipment") {
           throw new GiTcgDataError(
             "`on staged` is only available for support and equipment.",
           );
         }
-        model.stagedOperations.push(operation);
+        const stagedAction = StagedOperationVM.parse(subView);
+        model.stagedOperations.push(stagedAction.action);
         return;
       }
       if (
         eventName === "enter" &&
-        (model.type === "support" || model.type === "equipment")
+        !(["status", "combatStatus", "summon"].includes(model.type))
       ) {
         throw new GiTcgDataError(
-          "Support and equipment cannot define `on enter`; use `on staged, :{ ... };` instead.",
+          "Only status, combatStatus, and summon can have `enter` handling. For support and equipment, use `on staged { ... };` instead.",
         );
       }
       const skillModel = TriggeredSkillViewModel.parse(

--- a/packages/core/src/gts/vm_impl/entity.ts
+++ b/packages/core/src/gts/vm_impl/entity.ts
@@ -927,7 +927,9 @@ export class EntityViewModel extends defineViewModel(
 
     on: h.attribute<{
       <Meta extends EntityVMMeta>(
-        this: AR.This<Meta>,
+        this: Meta["type"] extends "support" | "equipment"
+          ? AR.This<Meta>
+          : never,
         eventName: "staged",
       ): AR.With<StagedOperationVM, Meta>;
       <Meta extends EntityVMMeta, const Event extends DetailedEventNames>(
@@ -965,11 +967,6 @@ export class EntityViewModel extends defineViewModel(
       ): Meta;
     }>((model, [eventName], subView) => {
       if (eventName === "staged") {
-        if (model.type !== "support" && model.type !== "equipment") {
-          throw new GiTcgDataError(
-            "`on staged` is only available for support and equipment.",
-          );
-        }
         const stagedAction = StagedOperationVM.parse(subView);
         model.stagedOperations.push(stagedAction.action);
         return;

--- a/packages/core/src/runtime/skill.ts
+++ b/packages/core/src/runtime/skill.ts
@@ -590,11 +590,8 @@ export const detailedEventDictionary = {
   selectCard: defineDescriptor("onSelectCard", (e, r) => {
     return checkRelative(e.onTimeState, { who: e.who }, r);
   }),
-  adventure: defineDescriptor("onEnter", (e, r) => {
-    return (
-      checkRelative(e.onTimeState, { who: e.who }, r) &&
-      (e.entity as EntityState).definition.tags.includes("adventureSpot")
-    );
+  adventure: defineDescriptor("onAdventure", (e, r) => {
+    return checkRelative(e.onTimeState, { who: e.who }, r);
   }),
   customEvent: defineDescriptor("onCustomEvent", (e, r) => {
     return checkRelative(e.onTimeState, e.entity.id, r);

--- a/packages/core/src/skill_executor.ts
+++ b/packages/core/src/skill_executor.ts
@@ -17,6 +17,7 @@ import {
   type CoreSkillResult,
   defineSkillInfo,
   DisposeEventArg,
+  EntityEventArg,
   type Event,
   type EventAndRequest,
   EventArg,
@@ -476,27 +477,21 @@ export class SkillExecutor {
         const currentSpot = hisSupports.find((et) =>
           et.definition.tags.includes("adventureSpot"),
         );
+        let selectCardInfo: SelectCardInfo | null = null;
         if (currentSpot) {
-          const { events } = this.mutator.insertEntityOnStage(
-            { definition: currentSpot.definition },
-            {
-              type: "supports",
-              who: arg.who,
-            },
-            {
-              modifyOverriddenVariablesOnly: true,
-              overrideVariables: {
-                exp: 1,
-              },
-            },
-          );
-          await this.handleEvent(...events);
+          this.mutate({
+            type: "modifyEntityVar",
+            state: currentSpot,
+            varName: "exp",
+            value: currentSpot.variables.exp + 1,
+            direction: "increase",
+          });
         } else if (hisSupports.length < this.state.config.maxSupportsCount) {
           const spots = this.state.data.entities
             .values()
             .filter((d) => d.tags.includes("adventureSpot"))
             .toArray();
-          const selectCardInfo: SelectCardInfo = {
+          selectCardInfo = {
             type: "requestPlayCard",
             cards: spots,
             targets: [],
@@ -507,6 +502,17 @@ export class SkillExecutor {
             selectCardInfo,
           );
           await this.handleEvent(...events);
+        }
+        const adventureSpot = this.state.players[arg.who].supports.find((et) =>
+          et.definition.tags.includes("adventureSpot"),
+        );
+        if (adventureSpot) {
+          await this.handleEvent([
+            "onAdventure",
+            new EntityEventArg(this.state, adventureSpot),
+          ]);
+        }
+        if (selectCardInfo) {
           await this.handleEvent([
             "onSelectCard",
             new SelectCardEventArg(this.state, arg.who, selectCardInfo),

--- a/packages/data/src/cards/equipment/artifacts.gts
+++ b/packages/data/src/cards/equipment/artifacts.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  Reaction,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, Reaction } from "@gi-tcg/core/data";
 import {
   AdventureCompleted,
   BondOfLife,
@@ -768,9 +763,10 @@ define card {
     variable bubble, 0;
     replaceDescription "[GCG_TOKEN_SHIELD]",
       ((_, self) => self.variables.healedPts);
-    on enter {
-      :heal(2, :self.master);
-    };
+    on staged,
+      :{
+        :heal(2, :self.master);
+      };
     on healed {
       listenTo samePlayer;
       :addVariable("healedPts", :e.value);
@@ -801,9 +797,10 @@ define card {
   since "v4.2.0";
   cost DiceType.Aligned, 1;
   artifact {
-    on enter {
-      :drawCards(1);
-    };
+    on staged,
+      :{
+        :drawCards(1);
+      };
     on damaged {
       when :(
         !:e.target.isMine() && :self.master.isActive() && :e.getReaction()
@@ -828,17 +825,18 @@ define card {
   since "v4.3.0";
   cost DiceType.Aligned, 3;
   artifact {
-    on enter {
-      const diceType = :self.master.element();
-      const elementKinds = new Set(
-        :queryAll($.my.character.includesDefeated).map((ch) => ch.element()),
-      );
-      if (elementKinds.size >= 3) {
-        :generateDice(diceType, 2);
-      } else {
-        :generateDice(diceType, 1);
-      }
-    };
+    on staged,
+      :{
+        const diceType = :self.master.element();
+        const elementKinds = new Set(
+          :queryAll($.my.character.includesDefeated).map((ch) => ch.element()),
+        );
+        if (elementKinds.size >= 3) {
+          :generateDice(diceType, 2);
+        } else {
+          :generateDice(diceType, 1);
+        }
+      };
     on damaged {
       when :(
         !:e.target.isMine() && :self.master.isActive() && :e.getReaction()
@@ -1527,9 +1525,10 @@ define card {
   since "v6.1.0";
   cost DiceType.Void, 3;
   artifact {
-    on enter {
-      :gainEnergy(1, :self.master);
-    };
+    on staged,
+      :{
+        :gainEnergy(1, :self.master);
+      };
     on useSkill {
       when :( :e.isSkillType("burst") );
       :combatStatus(NoblesseObligeInEffect);

--- a/packages/data/src/cards/equipment/artifacts.gts
+++ b/packages/data/src/cards/equipment/artifacts.gts
@@ -763,10 +763,9 @@ define card {
     variable bubble, 0;
     replaceDescription "[GCG_TOKEN_SHIELD]",
       ((_, self) => self.variables.healedPts);
-    on staged,
-      :{
-        :heal(2, :self.master);
-      };
+    on staged {
+      :heal(2, :self.master);
+    };
     on healed {
       listenTo samePlayer;
       :addVariable("healedPts", :e.value);
@@ -797,10 +796,9 @@ define card {
   since "v4.2.0";
   cost DiceType.Aligned, 1;
   artifact {
-    on staged,
-      :{
-        :drawCards(1);
-      };
+    on staged {
+      :drawCards(1);
+    };
     on damaged {
       when :(
         !:e.target.isMine() && :self.master.isActive() && :e.getReaction()
@@ -825,18 +823,17 @@ define card {
   since "v4.3.0";
   cost DiceType.Aligned, 3;
   artifact {
-    on staged,
-      :{
-        const diceType = :self.master.element();
-        const elementKinds = new Set(
-          :queryAll($.my.character.includesDefeated).map((ch) => ch.element()),
-        );
-        if (elementKinds.size >= 3) {
-          :generateDice(diceType, 2);
-        } else {
-          :generateDice(diceType, 1);
-        }
-      };
+    on staged {
+      const diceType = :self.master.element();
+      const elementKinds = new Set(
+        :queryAll($.my.character.includesDefeated).map((ch) => ch.element()),
+      );
+      if (elementKinds.size >= 3) {
+        :generateDice(diceType, 2);
+      } else {
+        :generateDice(diceType, 1);
+      }
+    };
     on damaged {
       when :(
         !:e.target.isMine() && :self.master.isActive() && :e.getReaction()
@@ -1525,10 +1522,9 @@ define card {
   since "v6.1.0";
   cost DiceType.Void, 3;
   artifact {
-    on staged,
-      :{
-        :gainEnergy(1, :self.master);
-      };
+    on staged {
+      :gainEnergy(1, :self.master);
+    };
     on useSkill {
       when :( :e.isSkillType("burst") );
       :combatStatus(NoblesseObligeInEffect);

--- a/packages/data/src/cards/equipment/techniques.gts
+++ b/packages/data/src/cards/equipment/techniques.gts
@@ -207,10 +207,9 @@ define card {
     variable deductDiceTriggered, 0 {
       visible false;
     };
-    on staged,
-      :{
-        :characterStatus(Target, $.opp.active);
-      };
+    on staged {
+      :characterStatus(Target, $.opp.active);
+    };
     on switchActive {
       when :(
         !:e.switchInfo.to.isMine() && :e.switchInfo.to.hasStatus(Target)
@@ -266,10 +265,9 @@ define card {
       cost DiceType.Aligned, 1;
       :damage(DamageType.Physical, 2);
     };
-    on staged,
-      :{
-        :characterStatus(WaveriderShield, :self.master);
-      };
+    on staged {
+      :characterStatus(WaveriderShield, :self.master);
+    };
     on switchActive {
       when :( :e.switchInfo.from?.id === :self.master.id );
       :addVariable("usage", 1);
@@ -413,10 +411,9 @@ define card {
   since "v5.7.0";
   cost DiceType.Aligned, 2;
   technique {
-    on staged,
-      :{
-        :combatStatus(Yikes);
-      };
+    on staged {
+      :combatStatus(Yikes);
+    };
     skill {
       id 3130092;
       usage 2;

--- a/packages/data/src/cards/equipment/techniques.gts
+++ b/packages/data/src/cards/equipment/techniques.gts
@@ -348,14 +348,13 @@ define combatStatus {
   id 301306 as Yikes;
   associateExtension TechniquesPlayedCountExtension;
   variable techniquesPlayedCount, 0;
-  defineSnippet checkCount,
-    :{
-      if (:getVariable("techniquesPlayedCount") >= 6) {
-        :characterStatus(SaurianBuddyCheers, $.my.active);
-        :damage(DamageType.Physical, 3);
-        :dispose();
-      }
-    };
+  defineSnippet checkCount {
+    if (:getVariable("techniquesPlayedCount") >= 6) {
+      :characterStatus(SaurianBuddyCheers, $.my.active);
+      :damage(DamageType.Physical, 3);
+      :dispose();
+    }
+  };
   on enter {
     :setVariable(
       "techniquesPlayedCount",

--- a/packages/data/src/cards/equipment/techniques.gts
+++ b/packages/data/src/cards/equipment/techniques.gts
@@ -14,12 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import type { EntityDefinition } from "@gi-tcg/core";
-import {
-  $,
-  DamageType,
-  DiceType,
-  type StatusHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type StatusHandle } from "@gi-tcg/core/data";
 import { AgileSwitch, EfficientSwitch } from "../../commons.gts";
 
 /**
@@ -212,9 +207,10 @@ define card {
     variable deductDiceTriggered, 0 {
       visible false;
     };
-    on enter {
-      :characterStatus(Target, $.opp.active);
-    };
+    on staged,
+      :{
+        :characterStatus(Target, $.opp.active);
+      };
     on switchActive {
       when :(
         !:e.switchInfo.to.isMine() && :e.switchInfo.to.hasStatus(Target)
@@ -270,9 +266,10 @@ define card {
       cost DiceType.Aligned, 1;
       :damage(DamageType.Physical, 2);
     };
-    on enter {
-      :characterStatus(WaveriderShield, :self.master);
-    };
+    on staged,
+      :{
+        :characterStatus(WaveriderShield, :self.master);
+      };
     on switchActive {
       when :( :e.switchInfo.from?.id === :self.master.id );
       :addVariable("usage", 1);
@@ -416,9 +413,10 @@ define card {
   since "v5.7.0";
   cost DiceType.Aligned, 2;
   technique {
-    on enter {
-      :combatStatus(Yikes);
-    };
+    on staged,
+      :{
+        :combatStatus(Yikes);
+      };
     skill {
       id 3130092;
       usage 2;

--- a/packages/data/src/cards/equipment/weapon/bow.gts
+++ b/packages/data/src/cards/equipment/weapon/bow.gts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { $, DiceType} from "@gi-tcg/core/data";
+import { $, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 311201
@@ -174,9 +174,10 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on enter {
-      :characterStatus(KingsSquireStatus, :self.master);
-    };
+    on staged,
+      :{
+        :characterStatus(KingsSquireStatus, :self.master);
+      };
   };
 };
 
@@ -261,9 +262,10 @@ define card {
       when :( :self.master.health >= 11 );
       :e.increaseDamage(2);
     };
-    on enter {
-      :increaseMaxHealth(1, :self.master);
-    };
+    on staged,
+      :{
+        :increaseMaxHealth(1, :self.master);
+      };
   };
 };
 

--- a/packages/data/src/cards/equipment/weapon/bow.gts
+++ b/packages/data/src/cards/equipment/weapon/bow.gts
@@ -174,10 +174,9 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on staged,
-      :{
-        :characterStatus(KingsSquireStatus, :self.master);
-      };
+    on staged {
+      :characterStatus(KingsSquireStatus, :self.master);
+    };
   };
 };
 
@@ -262,10 +261,9 @@ define card {
       when :( :self.master.health >= 11 );
       :e.increaseDamage(2);
     };
-    on staged,
-      :{
-        :increaseMaxHealth(1, :self.master);
-      };
+    on staged {
+      :increaseMaxHealth(1, :self.master);
+    };
   };
 };
 

--- a/packages/data/src/cards/equipment/weapon/catalyst.gts
+++ b/packages/data/src/cards/equipment/weapon/catalyst.gts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { $, DamageType, DiceType} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import { BondOfLife } from "../../../commons.gts";
 
 /**
@@ -123,9 +123,10 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on enter {
-      :drawCards(2);
-    };
+    on staged,
+      :{
+        :drawCards(2);
+      };
   };
 };
 
@@ -298,9 +299,10 @@ define card {
   since "v5.2.0";
   cost DiceType.Aligned, 1;
   weapon catalyst {
-    on enter {
-      :characterStatus(BondOfLife, :self.master);
-    };
+    on staged,
+      :{
+        :characterStatus(BondOfLife, :self.master);
+      };
     on endPhase {
       :characterStatus(BondOfLife, :self.master);
     };
@@ -331,9 +333,10 @@ define card {
       when :( :self.master.health >= 11 );
       :e.increaseDamage(2);
     };
-    on enter {
-      :increaseMaxHealth(1, :self.master);
-    };
+    on staged,
+      :{
+        :increaseMaxHealth(1, :self.master);
+      };
   };
 };
 

--- a/packages/data/src/cards/equipment/weapon/catalyst.gts
+++ b/packages/data/src/cards/equipment/weapon/catalyst.gts
@@ -123,10 +123,9 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on staged,
-      :{
-        :drawCards(2);
-      };
+    on staged {
+      :drawCards(2);
+    };
   };
 };
 
@@ -299,10 +298,9 @@ define card {
   since "v5.2.0";
   cost DiceType.Aligned, 1;
   weapon catalyst {
-    on staged,
-      :{
-        :characterStatus(BondOfLife, :self.master);
-      };
+    on staged {
+      :characterStatus(BondOfLife, :self.master);
+    };
     on endPhase {
       :characterStatus(BondOfLife, :self.master);
     };
@@ -333,10 +331,9 @@ define card {
       when :( :self.master.health >= 11 );
       :e.increaseDamage(2);
     };
-    on staged,
-      :{
-        :increaseMaxHealth(1, :self.master);
-      };
+    on staged {
+      :increaseMaxHealth(1, :self.master);
+    };
   };
 };
 

--- a/packages/data/src/cards/equipment/weapon/claymore.gts
+++ b/packages/data/src/cards/equipment/weapon/claymore.gts
@@ -222,10 +222,9 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on staged,
-      :{
-        :characterStatus(ForestRegaliaInEffect, :self.master);
-      };
+    on staged {
+      :characterStatus(ForestRegaliaInEffect, :self.master);
+    };
   };
 };
 
@@ -266,10 +265,9 @@ define card {
     associateExtension NonInitialPlayedCardExtension;
     replaceDescription "[GCG_TOKEN_COUNTER]",
       ((_, { area }, ext) => ext.defIds[area.who].length);
-    on staged,
-      :{
-        :setVariable("supp", :getExtensionState().defIds[:self.who].length);
-      };
+    on staged {
+      :setVariable("supp", :getExtensionState().defIds[:self.who].length);
+    };
     on playCard {
       :setVariable("supp", :getExtensionState().defIds[:self.who].length);
     };

--- a/packages/data/src/cards/equipment/weapon/claymore.gts
+++ b/packages/data/src/cards/equipment/weapon/claymore.gts
@@ -13,10 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 311301
@@ -225,9 +222,10 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on enter {
-      :characterStatus(ForestRegaliaInEffect, :self.master);
-    };
+    on staged,
+      :{
+        :characterStatus(ForestRegaliaInEffect, :self.master);
+      };
   };
 };
 
@@ -268,9 +266,10 @@ define card {
     associateExtension NonInitialPlayedCardExtension;
     replaceDescription "[GCG_TOKEN_COUNTER]",
       ((_, { area }, ext) => ext.defIds[area.who].length);
-    on enter {
-      :setVariable("supp", :getExtensionState().defIds[:self.who].length);
-    };
+    on staged,
+      :{
+        :setVariable("supp", :getExtensionState().defIds[:self.who].length);
+      };
     on playCard {
       :setVariable("supp", :getExtensionState().defIds[:self.who].length);
     };

--- a/packages/data/src/cards/equipment/weapon/pole.gts
+++ b/packages/data/src/cards/equipment/weapon/pole.gts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { $, DiceType} from "@gi-tcg/core/data";
+import { $, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 311401
@@ -60,18 +60,19 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on enter {
-      const liyueCount = :queryAll(
-        $.my.character.includesDefeated.tag("liyue"),
-      ).length;
-      if (liyueCount > 0) {
-        :characterStatus(LithicGuard, :self.master, {
-          overrideVariables: {
-            shield: Math.min(liyueCount, 3),
-          },
-        });
-      }
-    };
+    on staged,
+      :{
+        const liyueCount = :queryAll(
+          $.my.character.includesDefeated.tag("liyue"),
+        ).length;
+        if (liyueCount > 0) {
+          :characterStatus(LithicGuard, :self.master, {
+            overrideVariables: {
+              shield: Math.min(liyueCount, 3),
+            },
+          });
+        }
+      };
   };
 };
 
@@ -152,10 +153,12 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on enter {
-      when :( :self.master.energy === 0 );
-      :gainEnergy(1, :self.master);
-    };
+    on staged,
+      :{
+        if (:self.master.energy === 0) {
+          :gainEnergy(1, :self.master);
+        }
+      };
     on actionPhase {
       when :( :self.master.energy === 0 );
       :gainEnergy(1, :self.master);
@@ -194,9 +197,10 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on enter {
-      :characterStatus(MoonpiercerStatus, :self.master);
-    };
+    on staged,
+      :{
+        :characterStatus(MoonpiercerStatus, :self.master);
+      };
   };
 };
 

--- a/packages/data/src/cards/equipment/weapon/pole.gts
+++ b/packages/data/src/cards/equipment/weapon/pole.gts
@@ -60,19 +60,18 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on staged,
-      :{
-        const liyueCount = :queryAll(
-          $.my.character.includesDefeated.tag("liyue"),
-        ).length;
-        if (liyueCount > 0) {
-          :characterStatus(LithicGuard, :self.master, {
-            overrideVariables: {
-              shield: Math.min(liyueCount, 3),
-            },
-          });
-        }
-      };
+    on staged {
+      const liyueCount = :queryAll(
+        $.my.character.includesDefeated.tag("liyue"),
+      ).length;
+      if (liyueCount > 0) {
+        :characterStatus(LithicGuard, :self.master, {
+          overrideVariables: {
+            shield: Math.min(liyueCount, 3),
+          },
+        });
+      }
+    };
   };
 };
 
@@ -153,12 +152,11 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on staged,
-      :{
-        if (:self.master.energy === 0) {
-          :gainEnergy(1, :self.master);
-        }
-      };
+    on staged {
+      if (:self.master.energy === 0) {
+        :gainEnergy(1, :self.master);
+      }
+    };
     on actionPhase {
       when :( :self.master.energy === 0 );
       :gainEnergy(1, :self.master);
@@ -197,10 +195,9 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on staged,
-      :{
-        :characterStatus(MoonpiercerStatus, :self.master);
-      };
+    on staged {
+      :characterStatus(MoonpiercerStatus, :self.master);
+    };
   };
 };
 

--- a/packages/data/src/cards/equipment/weapon/sword.gts
+++ b/packages/data/src/cards/equipment/weapon/sword.gts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { $, DiceType} from "@gi-tcg/core/data";
+import { $, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 311501
@@ -185,9 +185,10 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on enter {
-      :characterStatus(SapwoodBladeStatus, :self.master);
-    };
+    on staged,
+      :{
+        :characterStatus(SapwoodBladeStatus, :self.master);
+      };
   };
 };
 

--- a/packages/data/src/cards/equipment/weapon/sword.gts
+++ b/packages/data/src/cards/equipment/weapon/sword.gts
@@ -185,10 +185,9 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on staged,
-      :{
-        :characterStatus(SapwoodBladeStatus, :self.master);
-      };
+    on staged {
+      :characterStatus(SapwoodBladeStatus, :self.master);
+    };
   };
 };
 

--- a/packages/data/src/cards/event/food.gts
+++ b/packages/data/src/cards/event/food.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DiceType,
-  type StatusHandle,
-} from "@gi-tcg/core/data";
+import { $, DiceType, type StatusHandle } from "@gi-tcg/core/data";
 import { BattlePlan, Satiated, SharpenTheBlade } from "../../commons.gts";
 
 /**

--- a/packages/data/src/cards/event/legend.gts
+++ b/packages/data/src/cards/event/legend.gts
@@ -364,12 +364,11 @@ define card {
   support {
     variable spirit, 0;
     associateExtension FlamesOfWarExtension;
-    on staged,
-      :{
-        :setExtensionState((st) => {
-          st.spirit[:self.who] = :getVariable("spirit");
-        });
-      };
+    on staged {
+      :setExtensionState((st) => {
+        st.spirit[:self.who] = :getVariable("spirit");
+      });
+    };
     on dealDamage {
       :setVariable("spirit", :getExtensionState().spirit[:self.who]);
     };

--- a/packages/data/src/cards/event/legend.gts
+++ b/packages/data/src/cards/event/legend.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DiceType,
-  flip,
-} from "@gi-tcg/core/data";
+import { $, DiceType, flip } from "@gi-tcg/core/data";
 import { DisperseTheCalamity, SanctifyTheDefiled } from "./other.gts";
 import { IneffectiveWhenPlayed } from "../../commons.gts";
 
@@ -368,11 +364,12 @@ define card {
   support {
     variable spirit, 0;
     associateExtension FlamesOfWarExtension;
-    on enter {
-      :setExtensionState((st) => {
-        st.spirit[:self.who] = :getVariable("spirit");
-      });
-    };
+    on staged,
+      :{
+        :setExtensionState((st) => {
+          st.spirit[:self.who] = :getVariable("spirit");
+        });
+      };
     on dealDamage {
       :setVariable("spirit", :getExtensionState().spirit[:self.who]);
     };

--- a/packages/data/src/cards/support/adventure.gts
+++ b/packages/data/src/cards/support/adventure.gts
@@ -96,10 +96,10 @@ define card {
   undiscoverable;
   support place {
     adventureSpot;
-    on enter {
-      when :( !:e.overridden );
-      :damage(DamageType.Piercing, 1, $.my.character);
-    };
+    on staged,
+      :{
+        :damage(DamageType.Piercing, 1, $.my.character);
+      };
     on adventure {
       when :( :getVariable("exp") % 2 === 0 );
       :generateDice("randomElement", 1);
@@ -246,19 +246,19 @@ define card {
   undiscoverable;
   support place {
     adventureSpot;
-    on enter {
-      when :( !:e.overridden );
-      const excludeTags = ["food", "legend"] as const;
-      const candidates = :allCardDefinitions(
-        (card) =>
-          card.type === "eventCard" &&
-          !excludeTags.some((tag) => card.tags.includes(tag)),
-      );
-      const cards = :randomSubset(candidates, 5);
-      for (const card of cards) {
-        :createPileCards(card.id as CardHandle, 1, "random");
-      }
-    };
+    on staged,
+      :{
+        const excludeTags = ["food", "legend"] as const;
+        const candidates = :allCardDefinitions(
+          (card) =>
+            card.type === "eventCard" &&
+            !excludeTags.some((tag) => card.tags.includes(tag)),
+        );
+        const cards = :randomSubset(candidates, 5);
+        for (const card of cards) {
+          :createPileCards(card.id as CardHandle, 1, "random");
+        }
+      };
     on adventure {
       when :( :getVariable("exp") % 2 === 0 );
       :generateDice("randomElement", 1);

--- a/packages/data/src/cards/support/adventure.gts
+++ b/packages/data/src/cards/support/adventure.gts
@@ -96,10 +96,9 @@ define card {
   undiscoverable;
   support place {
     adventureSpot;
-    on staged,
-      :{
-        :damage(DamageType.Piercing, 1, $.my.character);
-      };
+    on staged {
+      :damage(DamageType.Piercing, 1, $.my.character);
+    };
     on adventure {
       when :( :getVariable("exp") % 2 === 0 );
       :generateDice("randomElement", 1);
@@ -246,19 +245,18 @@ define card {
   undiscoverable;
   support place {
     adventureSpot;
-    on staged,
-      :{
-        const excludeTags = ["food", "legend"] as const;
-        const candidates = :allCardDefinitions(
-          (card) =>
-            card.type === "eventCard" &&
-            !excludeTags.some((tag) => card.tags.includes(tag)),
-        );
-        const cards = :randomSubset(candidates, 5);
-        for (const card of cards) {
-          :createPileCards(card.id as CardHandle, 1, "random");
-        }
-      };
+    on staged {
+      const excludeTags = ["food", "legend"] as const;
+      const candidates = :allCardDefinitions(
+        (card) =>
+          card.type === "eventCard" &&
+          !excludeTags.some((tag) => card.tags.includes(tag)),
+      );
+      const cards = :randomSubset(candidates, 5);
+      for (const card of cards) {
+        :createPileCards(card.id as CardHandle, 1, "random");
+      }
+    };
     on adventure {
       when :( :getVariable("exp") % 2 === 0 );
       :generateDice("randomElement", 1);

--- a/packages/data/src/cards/support/ally.gts
+++ b/packages/data/src/cards/support/ally.gts
@@ -97,15 +97,14 @@ define card {
   cost DiceType.Aligned, 2;
   support ally {
     variable material, 2;
-    on staged,
-      :{
-        if (
-          :player.initialPile.filter((card) => card.tags.includes("artifact"))
-            .length >= 6
-        ) {
-          :drawCards(1, { withTag: "artifact" });
-        }
-      };
+    on staged {
+      if (
+        :player.initialPile.filter((card) => card.tags.includes("artifact"))
+          .length >= 6
+      ) {
+        :drawCards(1, { withTag: "artifact" });
+      }
+    };
     on endPhase {
       :addVariable("material", 1);
     };
@@ -135,16 +134,15 @@ define card {
   cost DiceType.Aligned, 2;
   support ally {
     variable material, 2;
-    on staged,
-      :{
-        const weaponDefs = :player.initialPile
-          .filter((card) => card.tags.includes("weapon"))
-          .map((card) => card.id);
-        const weaponKinds = new Set(weaponDefs).size;
-        if (weaponKinds >= 3) {
-          :drawCards(1, { withTag: "weapon" });
-        }
-      };
+    on staged {
+      const weaponDefs = :player.initialPile
+        .filter((card) => card.tags.includes("weapon"))
+        .map((card) => card.id);
+      const weaponKinds = new Set(weaponDefs).size;
+      if (weaponKinds >= 3) {
+        :drawCards(1, { withTag: "weapon" });
+      }
+    };
     on endPhase {
       :addVariable("material", 1);
     };
@@ -618,13 +616,12 @@ define card {
   support ally {
     associateExtension DisposedSupportCountExtension;
     variable experience, 0;
-    on staged,
-      :{
-        :setVariable(
-          "experience",
-          Math.min(:getExtensionState().disposedSupportCount[:self.who], 6),
-        );
-      };
+    on staged {
+      :setVariable(
+        "experience",
+        Math.min(:getExtensionState().disposedSupportCount[:self.who], 6),
+      );
+    };
     on dispose {
       when :( :e.entity.definition.type === "support" );
       :setVariable(
@@ -685,11 +682,10 @@ define card {
   support ally {
     associateExtension DamageTypeCountExtension;
     variable count, 0;
-    on staged,
-      :{
-        const count = :getExtensionState().damages[flip(:self.who)].length;
-        :setVariable("count", Math.min(count, 4));
-      };
+    on staged {
+      const count = :getExtensionState().damages[flip(:self.who)].length;
+      :setVariable("count", Math.min(count, 4));
+    };
     on damaged {
       when :( !:e.target.isMine() );
       listenTo all;
@@ -735,10 +731,9 @@ define card {
   cost DiceType.Void, 2;
   support ally {
     variable count, 0;
-    on staged,
-      :{
-        :createPileCards(TaroumarusSavings, 4, "spaceAround");
-      };
+    on staged {
+      :createPileCards(TaroumarusSavings, 4, "spaceAround");
+    };
     on playCard {
       when :( :e.card.definition.id === TaroumarusSavings );
       :addVariable("count", 1);
@@ -873,11 +868,10 @@ define card {
   since "v4.8.0";
   cost DiceType.Void, 2;
   support ally {
-    on staged,
-      :{
-        const card = :random(SERENE_SUPPORTS);
-        :createHandCard(card);
-      };
+    on staged {
+      const card = :random(SERENE_SUPPORTS);
+      :createHandCard(card);
+    };
     on actionPhase {
       usage 2;
       const card = :random(SERENE_SUPPORTS);
@@ -923,10 +917,9 @@ define card {
       ]);
       :createHandCard(newCard);
     };
-    on staged,
-      :{
-        :callSnippet();
-      };
+    on staged {
+      :callSnippet();
+    };
     on reaction {
       when :( :e.caller.isMine() );
       listenTo all;
@@ -948,12 +941,11 @@ define card {
   since "v5.8.0";
   cost DiceType.Void, 2;
   support ally {
-    on staged,
-      :{
-        :createHandCard(ToyGuard);
-        :createHandCard(ToyGuard);
-        :createPileCards(ToyGuard, 2, "random");
-      };
+    on staged {
+      :createHandCard(ToyGuard);
+      :createHandCard(ToyGuard);
+      :createPileCards(ToyGuard, 2, "random");
+    };
     on enterRelative {
       when :(
         :e.entity.definition.type === "summon" &&
@@ -977,13 +969,12 @@ define card {
   since "v6.2.0";
   cost DiceType.Aligned, 1;
   support ally {
-    on staged,
-      :{
-        const oppTop = :oppPlayer.pile[0];
-        if (oppTop) {
-          :createHandCard(oppTop.definition.id as CardHandle);
-        }
-      };
+    on staged {
+      const oppTop = :oppPlayer.pile[0];
+      if (oppTop) {
+        :createHandCard(oppTop.definition.id as CardHandle);
+      }
+    };
     on playCard {
       when :( !:isInInitialPile(:e.card) );
       usage 2;
@@ -1005,10 +996,9 @@ define card {
   since "v6.3.0";
   cost DiceType.Void, 2;
   support ally {
-    on staged,
-      :{
-        :adventure();
-      };
+    on staged {
+      :adventure();
+    };
     on useTechnique {
       usage perRound, 1;
       :adventure();
@@ -1294,14 +1284,13 @@ define card {
   since "v6.5.0";
   support ally {
     variable progress, 0; // for transformed plans to use
-    on staged,
-      :{
-        :selectAndPlay([
-          LepinepaulinesInvestmentInMedicalEquipment,
-          LepinepaulinesInvestmentInGraphAdversarialTechnology,
-          LepinepaulinesInvestmentInEnergyMechanism,
-        ]);
-      };
+    on staged {
+      :selectAndPlay([
+        LepinepaulinesInvestmentInMedicalEquipment,
+        LepinepaulinesInvestmentInGraphAdversarialTechnology,
+        LepinepaulinesInvestmentInEnergyMechanism,
+      ]);
+    };
   };
 };
 

--- a/packages/data/src/cards/support/ally.gts
+++ b/packages/data/src/cards/support/ally.gts
@@ -909,7 +909,7 @@ define card {
   since "v5.8.0";
   cost DiceType.Void, 2;
   support ally {
-    defineSnippet :{
+    defineSnippet {
       const newCard = :random([
         OrigamiFlyingSquirrel,
         PopupPaperFrog,

--- a/packages/data/src/cards/support/ally.gts
+++ b/packages/data/src/cards/support/ally.gts
@@ -97,13 +97,15 @@ define card {
   cost DiceType.Aligned, 2;
   support ally {
     variable material, 2;
-    on enter {
-      when :(
-        :player.initialPile.filter((card) => card.tags.includes("artifact"))
-          .length >= 6
-      );
-      :drawCards(1, { withTag: "artifact" });
-    };
+    on staged,
+      :{
+        if (
+          :player.initialPile.filter((card) => card.tags.includes("artifact"))
+            .length >= 6
+        ) {
+          :drawCards(1, { withTag: "artifact" });
+        }
+      };
     on endPhase {
       :addVariable("material", 1);
     };
@@ -133,15 +135,16 @@ define card {
   cost DiceType.Aligned, 2;
   support ally {
     variable material, 2;
-    on enter {
-      const weaponDefs = :player.initialPile
-        .filter((card) => card.tags.includes("weapon"))
-        .map((card) => card.id);
-      const weaponKinds = new Set(weaponDefs).size;
-      if (weaponKinds >= 3) {
-        :drawCards(1, { withTag: "weapon" });
-      }
-    };
+    on staged,
+      :{
+        const weaponDefs = :player.initialPile
+          .filter((card) => card.tags.includes("weapon"))
+          .map((card) => card.id);
+        const weaponKinds = new Set(weaponDefs).size;
+        if (weaponKinds >= 3) {
+          :drawCards(1, { withTag: "weapon" });
+        }
+      };
     on endPhase {
       :addVariable("material", 1);
     };
@@ -615,12 +618,13 @@ define card {
   support ally {
     associateExtension DisposedSupportCountExtension;
     variable experience, 0;
-    on enter {
-      :setVariable(
-        "experience",
-        Math.min(:getExtensionState().disposedSupportCount[:self.who], 6),
-      );
-    };
+    on staged,
+      :{
+        :setVariable(
+          "experience",
+          Math.min(:getExtensionState().disposedSupportCount[:self.who], 6),
+        );
+      };
     on dispose {
       when :( :e.entity.definition.type === "support" );
       :setVariable(
@@ -681,10 +685,11 @@ define card {
   support ally {
     associateExtension DamageTypeCountExtension;
     variable count, 0;
-    on enter {
-      const count = :getExtensionState().damages[flip(:self.who)].length;
-      :setVariable("count", Math.min(count, 4));
-    };
+    on staged,
+      :{
+        const count = :getExtensionState().damages[flip(:self.who)].length;
+        :setVariable("count", Math.min(count, 4));
+      };
     on damaged {
       when :( !:e.target.isMine() );
       listenTo all;
@@ -730,9 +735,10 @@ define card {
   cost DiceType.Void, 2;
   support ally {
     variable count, 0;
-    on enter {
-      :createPileCards(TaroumarusSavings, 4, "spaceAround");
-    };
+    on staged,
+      :{
+        :createPileCards(TaroumarusSavings, 4, "spaceAround");
+      };
     on playCard {
       when :( :e.card.definition.id === TaroumarusSavings );
       :addVariable("count", 1);
@@ -867,10 +873,11 @@ define card {
   since "v4.8.0";
   cost DiceType.Void, 2;
   support ally {
-    on enter {
-      const card = :random(SERENE_SUPPORTS);
-      :createHandCard(card);
-    };
+    on staged,
+      :{
+        const card = :random(SERENE_SUPPORTS);
+        :createHandCard(card);
+      };
     on actionPhase {
       usage 2;
       const card = :random(SERENE_SUPPORTS);
@@ -916,9 +923,10 @@ define card {
       ]);
       :createHandCard(newCard);
     };
-    on enter {
-      :callSnippet();
-    };
+    on staged,
+      :{
+        :callSnippet();
+      };
     on reaction {
       when :( :e.caller.isMine() );
       listenTo all;
@@ -940,11 +948,12 @@ define card {
   since "v5.8.0";
   cost DiceType.Void, 2;
   support ally {
-    on enter {
-      :createHandCard(ToyGuard);
-      :createHandCard(ToyGuard);
-      :createPileCards(ToyGuard, 2, "random");
-    };
+    on staged,
+      :{
+        :createHandCard(ToyGuard);
+        :createHandCard(ToyGuard);
+        :createPileCards(ToyGuard, 2, "random");
+      };
     on enterRelative {
       when :(
         :e.entity.definition.type === "summon" &&
@@ -968,12 +977,13 @@ define card {
   since "v6.2.0";
   cost DiceType.Aligned, 1;
   support ally {
-    on enter {
-      const oppTop = :oppPlayer.pile[0];
-      if (oppTop) {
-        :createHandCard(oppTop.definition.id as CardHandle);
-      }
-    };
+    on staged,
+      :{
+        const oppTop = :oppPlayer.pile[0];
+        if (oppTop) {
+          :createHandCard(oppTop.definition.id as CardHandle);
+        }
+      };
     on playCard {
       when :( !:isInInitialPile(:e.card) );
       usage 2;
@@ -995,9 +1005,10 @@ define card {
   since "v6.3.0";
   cost DiceType.Void, 2;
   support ally {
-    on enter {
-      :adventure();
-    };
+    on staged,
+      :{
+        :adventure();
+      };
     on useTechnique {
       usage perRound, 1;
       :adventure();
@@ -1283,13 +1294,14 @@ define card {
   since "v6.5.0";
   support ally {
     variable progress, 0; // for transformed plans to use
-    on enter {
-      :selectAndPlay([
-        LepinepaulinesInvestmentInMedicalEquipment,
-        LepinepaulinesInvestmentInGraphAdversarialTechnology,
-        LepinepaulinesInvestmentInEnergyMechanism,
-      ]);
-    };
+    on staged,
+      :{
+        :selectAndPlay([
+          LepinepaulinesInvestmentInMedicalEquipment,
+          LepinepaulinesInvestmentInGraphAdversarialTechnology,
+          LepinepaulinesInvestmentInEnergyMechanism,
+        ]);
+      };
   };
 };
 

--- a/packages/data/src/cards/support/item.gts
+++ b/packages/data/src/cards/support/item.gts
@@ -13,10 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType } from "@gi-tcg/core/data";
 import { AgileSwitch, EfficientSwitch } from "../../commons.gts";
 
 /**
@@ -62,9 +59,10 @@ define card {
   since "v3.3.0";
   cost DiceType.Aligned, 1;
   support item {
-    on enter {
-      :drawCards(1, { withTag: "food" });
-    };
+    on staged,
+      :{
+        :drawCards(1, { withTag: "food" });
+      };
     on playCard {
       when :( :e.hasCardTag("food") );
       usage perRound, 1;

--- a/packages/data/src/cards/support/item.gts
+++ b/packages/data/src/cards/support/item.gts
@@ -59,10 +59,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Aligned, 1;
   support item {
-    on staged,
-      :{
-        :drawCards(1, { withTag: "food" });
-      };
+    on staged {
+      :drawCards(1, { withTag: "food" });
+    };
     on playCard {
       when :( :e.hasCardTag("food") );
       usage perRound, 1;

--- a/packages/data/src/cards/support/place.gts
+++ b/packages/data/src/cards/support/place.gts
@@ -1122,7 +1122,7 @@ define card {
   id 321041 as NightmareOmen;
   since "v6.7.0";
   support place {
-    defineSnippet :{
+    defineSnippet {
       const [oppTarget] = :maxCostHands(1, { who: "opp" });
       if (oppTarget) {
         :attachCostIncrease(oppTarget);

--- a/packages/data/src/cards/support/place.gts
+++ b/packages/data/src/cards/support/place.gts
@@ -67,10 +67,9 @@ define card {
   id 321002 as KnightsOfFavoniusLibrary;
   since "v3.3.0";
   support place {
-    on staged,
-      :{
-        :rerollDice(1);
-      };
+    on staged {
+      :rerollDice(1);
+    };
     on roll {
       :e.addRerollCount(1);
     };
@@ -366,10 +365,9 @@ define card {
   since "v4.2.0";
   cost DiceType.Aligned, 2;
   support place {
-    on staged,
-      :{
-        :drawCards(1, { withTag: "talent" });
-      };
+    on staged {
+      :drawCards(1, { withTag: "talent" });
+    };
     on deductOmniDice {
       when :{
         return (
@@ -877,15 +875,14 @@ define card {
   since "v5.8.0";
   cost DiceType.Void, 2;
   support place {
-    on staged,
-      :{
-        const newCard = :random([
-          OrigamiFlyingSquirrel,
-          PopupPaperFrog,
-          OrigamiHamster,
-        ]);
-        :createHandCard(newCard);
-      };
+    on staged {
+      const newCard = :random([
+        OrigamiFlyingSquirrel,
+        PopupPaperFrog,
+        OrigamiHamster,
+      ]);
+      :createHandCard(newCard);
+    };
     on declareEnd {
       when :( :query(SIMULANKA_QUERY) );
       usage 3;
@@ -939,10 +936,9 @@ define card {
   since "v5.8.0";
   cost DiceType.Aligned, 2;
   support place {
-    on staged,
-      :{
-        :createHandCard(ToyGuard);
-      };
+    on staged {
+      :createHandCard(ToyGuard);
+    };
     on useSkill {
       listenTo samePlayer;
       if (:e.isSkillType("elemental")) {
@@ -1041,11 +1037,10 @@ define card {
   since "v6.4.0";
   cost DiceType.Aligned, 4;
   support place {
-    on staged,
-      :{
-        :drawCards(2);
-        :heal(2, $.macros.myMostInjured);
-      };
+    on staged {
+      :drawCards(2);
+      :heal(2, $.macros.myMostInjured);
+    };
     on endPhase {
       usage 2;
       const chosen = :randomSubset(:queryAll($.macros.myHandsNotFree), 2);
@@ -1137,10 +1132,9 @@ define card {
         :attachCostIncrease(myPileTop);
       }
     };
-    on staged,
-      :{
-        :callSnippet();
-      };
+    on staged {
+      :callSnippet();
+    };
     on actionPhase {
       :callSnippet();
     };

--- a/packages/data/src/cards/support/place.gts
+++ b/packages/data/src/cards/support/place.gts
@@ -67,9 +67,10 @@ define card {
   id 321002 as KnightsOfFavoniusLibrary;
   since "v3.3.0";
   support place {
-    on enter {
-      :rerollDice(1);
-    };
+    on staged,
+      :{
+        :rerollDice(1);
+      };
     on roll {
       :e.addRerollCount(1);
     };
@@ -365,9 +366,10 @@ define card {
   since "v4.2.0";
   cost DiceType.Aligned, 2;
   support place {
-    on enter {
-      :drawCards(1, { withTag: "talent" });
-    };
+    on staged,
+      :{
+        :drawCards(1, { withTag: "talent" });
+      };
     on deductOmniDice {
       when :{
         return (
@@ -875,14 +877,15 @@ define card {
   since "v5.8.0";
   cost DiceType.Void, 2;
   support place {
-    on enter {
-      const newCard = :random([
-        OrigamiFlyingSquirrel,
-        PopupPaperFrog,
-        OrigamiHamster,
-      ]);
-      :createHandCard(newCard);
-    };
+    on staged,
+      :{
+        const newCard = :random([
+          OrigamiFlyingSquirrel,
+          PopupPaperFrog,
+          OrigamiHamster,
+        ]);
+        :createHandCard(newCard);
+      };
     on declareEnd {
       when :( :query(SIMULANKA_QUERY) );
       usage 3;
@@ -936,9 +939,10 @@ define card {
   since "v5.8.0";
   cost DiceType.Aligned, 2;
   support place {
-    on enter {
-      :createHandCard(ToyGuard);
-    };
+    on staged,
+      :{
+        :createHandCard(ToyGuard);
+      };
     on useSkill {
       listenTo samePlayer;
       if (:e.isSkillType("elemental")) {
@@ -1037,10 +1041,11 @@ define card {
   since "v6.4.0";
   cost DiceType.Aligned, 4;
   support place {
-    on enter {
-      :drawCards(2);
-      :heal(2, $.macros.myMostInjured);
-    };
+    on staged,
+      :{
+        :drawCards(2);
+        :heal(2, $.macros.myMostInjured);
+      };
     on endPhase {
       usage 2;
       const chosen = :randomSubset(:queryAll($.macros.myHandsNotFree), 2);
@@ -1132,9 +1137,10 @@ define card {
         :attachCostIncrease(myPileTop);
       }
     };
-    on enter {
-      :callSnippet();
-    };
+    on staged,
+      :{
+        :callSnippet();
+      };
     on actionPhase {
       :callSnippet();
     };

--- a/packages/data/src/characters/anemo/black_serpent_knight_windcutter.gts
+++ b/packages/data/src/characters/anemo/black_serpent_knight_windcutter.gts
@@ -183,10 +183,9 @@ define card {
   since "v6.7.0";
   cost DiceType.Anemo, 3;
   talent BlackSerpentKnightWindcutter {
-    on staged,
-      :{
-        :useSkill(RisingSlash);
-      };
+    on staged {
+      :useSkill(RisingSlash);
+    };
     on actionPhase {
       if (:oppPlayer.hands.length >= 7) {
         :characterStatus(RES, $.opp.active);

--- a/packages/data/src/characters/anemo/black_serpent_knight_windcutter.gts
+++ b/packages/data/src/characters/anemo/black_serpent_knight_windcutter.gts
@@ -183,9 +183,10 @@ define card {
   since "v6.7.0";
   cost DiceType.Anemo, 3;
   talent BlackSerpentKnightWindcutter {
-    on enter {
-      :useSkill(RisingSlash);
-    };
+    on staged,
+      :{
+        :useSkill(RisingSlash);
+      };
     on actionPhase {
       if (:oppPlayer.hands.length >= 7) {
         :characterStatus(RES, $.opp.active);

--- a/packages/data/src/characters/anemo/chasca.gts
+++ b/packages/data/src/characters/anemo/chasca.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-  $,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType, $ } from "@gi-tcg/core/data";
 
 /**
  * @id 115111

--- a/packages/data/src/characters/anemo/consecrated_flying_serpent.gts
+++ b/packages/data/src/characters/anemo/consecrated_flying_serpent.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import { BonecrunchersEnergyBlock } from "../../cards/event/other.gts";
 
 /**
@@ -162,9 +158,10 @@ define card {
   since "v4.7.0";
   cost DiceType.Anemo, 1;
   talent ConsecratedFlyingSerpent, none {
-    on enter {
-      :createHandCard(BonecrunchersEnergyBlock);
-    };
+    on staged,
+      :{
+        :createHandCard(BonecrunchersEnergyBlock);
+      };
     on playCard {
       when :( :e.card.definition.id === BonecrunchersEnergyBlock );
       :combatStatus(DeathlyCycloneInEffect);

--- a/packages/data/src/characters/anemo/consecrated_flying_serpent.gts
+++ b/packages/data/src/characters/anemo/consecrated_flying_serpent.gts
@@ -158,10 +158,9 @@ define card {
   since "v4.7.0";
   cost DiceType.Anemo, 1;
   talent ConsecratedFlyingSerpent, none {
-    on staged,
-      :{
-        :createHandCard(BonecrunchersEnergyBlock);
-      };
+    on staged {
+      :createHandCard(BonecrunchersEnergyBlock);
+    };
     on playCard {
       when :( :e.card.definition.id === BonecrunchersEnergyBlock );
       :combatStatus(DeathlyCycloneInEffect);

--- a/packages/data/src/characters/anemo/dvalin.gts
+++ b/packages/data/src/characters/anemo/dvalin.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 125024
@@ -212,9 +208,10 @@ define card {
   since "v4.3.0";
   cost DiceType.Anemo, 3;
   talent Dvalin {
-    on enter {
-      :useSkill(TempestuousBarrage);
-    };
+    on staged,
+      :{
+        :useSkill(TempestuousBarrage);
+      };
     on dispose {
       when :(
         :query($.opp.typeStatus.def(TotalCollapse))?.id === :e.entity.id

--- a/packages/data/src/characters/anemo/dvalin.gts
+++ b/packages/data/src/characters/anemo/dvalin.gts
@@ -208,10 +208,9 @@ define card {
   since "v4.3.0";
   cost DiceType.Anemo, 3;
   talent Dvalin {
-    on staged,
-      :{
-        :useSkill(TempestuousBarrage);
-      };
+    on staged {
+      :useSkill(TempestuousBarrage);
+    };
     on dispose {
       when :(
         :query($.opp.typeStatus.def(TotalCollapse))?.id === :e.entity.id

--- a/packages/data/src/characters/anemo/faruzan.gts
+++ b/packages/data/src/characters/anemo/faruzan.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 115093
@@ -199,8 +194,9 @@ define card {
   cost DiceType.Anemo, 3;
   cost DiceType.Energy, 2;
   talent Faruzan {
-    on enter {
-      :useSkill(TheWindsSecretWays);
-    };
+    on staged,
+      :{
+        :useSkill(TheWindsSecretWays);
+      };
   };
 };

--- a/packages/data/src/characters/anemo/faruzan.gts
+++ b/packages/data/src/characters/anemo/faruzan.gts
@@ -194,9 +194,8 @@ define card {
   cost DiceType.Anemo, 3;
   cost DiceType.Energy, 2;
   talent Faruzan {
-    on staged,
-      :{
-        :useSkill(TheWindsSecretWays);
-      };
+    on staged {
+      :useSkill(TheWindsSecretWays);
+    };
   };
 };

--- a/packages/data/src/characters/anemo/ifa.gts
+++ b/packages/data/src/characters/anemo/ifa.gts
@@ -219,9 +219,10 @@ define card {
   since "v6.1.0";
   cost DiceType.Anemo, 1;
   talent Ifa, none {
-    on enter {
-      :heal(1, $.macros.myMostInjured);
-    };
+    on staged,
+      :{
+        :heal(1, $.macros.myMostInjured);
+      };
     on dealReaction {
       when :(
         :e.relatedTo(DamageType.Anemo) ||

--- a/packages/data/src/characters/anemo/ifa.gts
+++ b/packages/data/src/characters/anemo/ifa.gts
@@ -219,10 +219,9 @@ define card {
   since "v6.1.0";
   cost DiceType.Anemo, 1;
   talent Ifa, none {
-    on staged,
-      :{
-        :heal(1, $.macros.myMostInjured);
-      };
+    on staged {
+      :heal(1, $.macros.myMostInjured);
+    };
     on dealReaction {
       when :(
         :e.relatedTo(DamageType.Anemo) ||

--- a/packages/data/src/characters/anemo/jean.gts
+++ b/packages/data/src/characters/anemo/jean.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SummonHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SummonHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 115021
@@ -117,8 +112,9 @@ define card {
   cost DiceType.Anemo, 4;
   cost DiceType.Energy, 2;
   talent Jean {
-    on enter {
-      :useSkill(DandelionBreeze);
-    };
+    on staged,
+      :{
+        :useSkill(DandelionBreeze);
+      };
   };
 };

--- a/packages/data/src/characters/anemo/jean.gts
+++ b/packages/data/src/characters/anemo/jean.gts
@@ -112,9 +112,8 @@ define card {
   cost DiceType.Anemo, 4;
   cost DiceType.Energy, 2;
   talent Jean {
-    on staged,
-      :{
-        :useSkill(DandelionBreeze);
-      };
+    on staged {
+      :useSkill(DandelionBreeze);
+    };
   };
 };

--- a/packages/data/src/characters/anemo/kaedehara_kazuha.gts
+++ b/packages/data/src/characters/anemo/kaedehara_kazuha.gts
@@ -369,10 +369,9 @@ define card {
   since "v3.8.0";
   cost DiceType.Anemo, 3;
   talent KaedeharaKazuha {
-    on staged,
-      :{
-        :useSkill(Chihayaburu);
-      };
+    on staged {
+      :useSkill(Chihayaburu);
+    };
     on dealDamage {
       when :( :e.isSwirl() );
       const swirled = :e.isSwirl()!;

--- a/packages/data/src/characters/anemo/kaedehara_kazuha.gts
+++ b/packages/data/src/characters/anemo/kaedehara_kazuha.gts
@@ -369,9 +369,10 @@ define card {
   since "v3.8.0";
   cost DiceType.Anemo, 3;
   talent KaedeharaKazuha {
-    on enter {
-      :useSkill(Chihayaburu);
-    };
+    on staged,
+      :{
+        :useSkill(Chihayaburu);
+      };
     on dealDamage {
       when :( :e.isSwirl() );
       const swirled = :e.isSwirl()!;

--- a/packages/data/src/characters/anemo/lan_yan.gts
+++ b/packages/data/src/characters/anemo/lan_yan.gts
@@ -115,10 +115,9 @@ define card {
   since "v5.8.0";
   cost DiceType.Anemo, 3;
   talent LanYan {
-    on staged,
-      :{
-        :useSkill(SwallowwispPinionDance);
-      };
+    on staged {
+      :useSkill(SwallowwispPinionDance);
+    };
     on useSkill {
       when :( :e.isSkillType("normal") );
       listenTo samePlayer;

--- a/packages/data/src/characters/anemo/lan_yan.gts
+++ b/packages/data/src/characters/anemo/lan_yan.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  Aura,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, Aura, DamageType, DiceType } from "@gi-tcg/core/data";
 import { EfficientSwitch } from "../../commons.gts";
 
 /**
@@ -120,9 +115,10 @@ define card {
   since "v5.8.0";
   cost DiceType.Anemo, 3;
   talent LanYan {
-    on enter {
-      :useSkill(SwallowwispPinionDance);
-    };
+    on staged,
+      :{
+        :useSkill(SwallowwispPinionDance);
+      };
     on useSkill {
       when :( :e.isSkillType("normal") );
       listenTo samePlayer;

--- a/packages/data/src/characters/anemo/lynette.gts
+++ b/packages/data/src/characters/anemo/lynette.gts
@@ -155,9 +155,8 @@ define card {
   since "v4.3.0";
   cost DiceType.Anemo, 3;
   talent Lynette {
-    on staged,
-      :{
-        :useSkill(EnigmaticFeint);
-      };
+    on staged {
+      :useSkill(EnigmaticFeint);
+    };
   };
 };

--- a/packages/data/src/characters/anemo/lynette.gts
+++ b/packages/data/src/characters/anemo/lynette.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 115083
@@ -160,8 +155,9 @@ define card {
   since "v4.3.0";
   cost DiceType.Anemo, 3;
   talent Lynette {
-    on enter {
-      :useSkill(EnigmaticFeint);
-    };
+    on staged,
+      :{
+        :useSkill(EnigmaticFeint);
+      };
   };
 };

--- a/packages/data/src/characters/anemo/maguu_kenki.gts
+++ b/packages/data/src/characters/anemo/maguu_kenki.gts
@@ -161,8 +161,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Anemo, 3;
   talent MaguuKenki {
-    on enter {
-      :useSkill(BlusteringBlade);
-    };
+    on staged,
+      :{
+        :useSkill(BlusteringBlade);
+      };
   };
 };

--- a/packages/data/src/characters/anemo/maguu_kenki.gts
+++ b/packages/data/src/characters/anemo/maguu_kenki.gts
@@ -161,9 +161,8 @@ define card {
   since "v3.3.0";
   cost DiceType.Anemo, 3;
   talent MaguuKenki {
-    on staged,
-      :{
-        :useSkill(BlusteringBlade);
-      };
+    on staged {
+      :useSkill(BlusteringBlade);
+    };
   };
 };

--- a/packages/data/src/characters/anemo/sayu.gts
+++ b/packages/data/src/characters/anemo/sayu.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  Aura,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, Aura, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 115072
@@ -171,9 +166,10 @@ define card {
   since "v4.4.0";
   cost DiceType.Anemo, 3;
   talent Sayu {
-    on enter {
-      :useSkill(YoohooArtFuuinDash);
-    };
+    on staged,
+      :{
+        :useSkill(YoohooArtFuuinDash);
+      };
     on dealDamage {
       when :( :self.master.isActive() && :e.isSwirl() );
       listenTo samePlayer;

--- a/packages/data/src/characters/anemo/sayu.gts
+++ b/packages/data/src/characters/anemo/sayu.gts
@@ -166,10 +166,9 @@ define card {
   since "v4.4.0";
   cost DiceType.Anemo, 3;
   talent Sayu {
-    on staged,
-      :{
-        :useSkill(YoohooArtFuuinDash);
-      };
+    on staged {
+      :useSkill(YoohooArtFuuinDash);
+    };
     on dealDamage {
       when :( :self.master.isActive() && :e.isSwirl() );
       listenTo samePlayer;

--- a/packages/data/src/characters/anemo/shikanoin_heizou.gts
+++ b/packages/data/src/characters/anemo/shikanoin_heizou.gts
@@ -260,8 +260,9 @@ define card {
   since "v5.8.0";
   cost DiceType.Anemo, 3;
   talent ShikanoinHeizou {
-    on enter {
-      :useSkill(HeartstopperStrike);
-    };
+    on staged,
+      :{
+        :useSkill(HeartstopperStrike);
+      };
   };
 };

--- a/packages/data/src/characters/anemo/shikanoin_heizou.gts
+++ b/packages/data/src/characters/anemo/shikanoin_heizou.gts
@@ -260,9 +260,8 @@ define card {
   since "v5.8.0";
   cost DiceType.Anemo, 3;
   talent ShikanoinHeizou {
-    on staged,
-      :{
-        :useSkill(HeartstopperStrike);
-      };
+    on staged {
+      :useSkill(HeartstopperStrike);
+    };
   };
 };

--- a/packages/data/src/characters/anemo/sucrose.gts
+++ b/packages/data/src/characters/anemo/sucrose.gts
@@ -138,9 +138,8 @@ define card {
   cost DiceType.Anemo, 3;
   cost DiceType.Energy, 2;
   talent Sucrose {
-    on staged,
-      :{
-        :useSkill(ForbiddenCreationIsomer75TypeIi);
-      };
+    on staged {
+      :useSkill(ForbiddenCreationIsomer75TypeIi);
+    };
   };
 };

--- a/packages/data/src/characters/anemo/sucrose.gts
+++ b/packages/data/src/characters/anemo/sucrose.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 115012
@@ -143,8 +138,9 @@ define card {
   cost DiceType.Anemo, 3;
   cost DiceType.Energy, 2;
   talent Sucrose {
-    on enter {
-      :useSkill(ForbiddenCreationIsomer75TypeIi);
-    };
+    on staged,
+      :{
+        :useSkill(ForbiddenCreationIsomer75TypeIi);
+      };
   };
 };

--- a/packages/data/src/characters/anemo/venti.gts
+++ b/packages/data/src/characters/anemo/venti.gts
@@ -159,9 +159,8 @@ define card {
   since "v3.7.0";
   cost DiceType.Anemo, 3;
   talent Venti {
-    on staged,
-      :{
-        :useSkill(SkywardSonnet);
-      };
+    on staged {
+      :useSkill(SkywardSonnet);
+    };
   };
 };

--- a/packages/data/src/characters/anemo/venti.gts
+++ b/packages/data/src/characters/anemo/venti.gts
@@ -159,8 +159,9 @@ define card {
   since "v3.7.0";
   cost DiceType.Anemo, 3;
   talent Venti {
-    on enter {
-      :useSkill(SkywardSonnet);
-    };
+    on staged,
+      :{
+        :useSkill(SkywardSonnet);
+      };
   };
 };

--- a/packages/data/src/characters/anemo/wanderer.gts
+++ b/packages/data/src/characters/anemo/wanderer.gts
@@ -132,10 +132,9 @@ define card {
   since "v4.1.0";
   cost DiceType.Anemo, 4;
   talent Wanderer {
-    on staged,
-      :{
-        :useSkill(HanegaSongOfTheWind);
-      };
+    on staged {
+      :useSkill(HanegaSongOfTheWind);
+    };
     on dealDamage {
       when :( :self.master.hasStatus(Windfavored) && :e.via.charged );
       :characterStatus(Descent, :self.master);

--- a/packages/data/src/characters/anemo/wanderer.gts
+++ b/packages/data/src/characters/anemo/wanderer.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 115062
@@ -136,9 +132,10 @@ define card {
   since "v4.1.0";
   cost DiceType.Anemo, 4;
   talent Wanderer {
-    on enter {
-      :useSkill(HanegaSongOfTheWind);
-    };
+    on staged,
+      :{
+        :useSkill(HanegaSongOfTheWind);
+      };
     on dealDamage {
       when :( :self.master.hasStatus(Windfavored) && :e.via.charged );
       :characterStatus(Descent, :self.master);

--- a/packages/data/src/characters/anemo/xianyun.gts
+++ b/packages/data/src/characters/anemo/xianyun.gts
@@ -175,10 +175,9 @@ define card {
   cost DiceType.Anemo, 3;
   talent Xianyun {
     variable feather, 0;
-    on staged,
-      :{
-        :useSkill(WhiteCloudsAtDawn);
-      };
+    on staged {
+      :useSkill(WhiteCloudsAtDawn);
+    };
     on switchActive {
       listenTo samePlayer;
       usage perRound, 2;

--- a/packages/data/src/characters/anemo/xianyun.gts
+++ b/packages/data/src/characters/anemo/xianyun.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 115103
@@ -179,9 +175,10 @@ define card {
   cost DiceType.Anemo, 3;
   talent Xianyun {
     variable feather, 0;
-    on enter {
-      :useSkill(WhiteCloudsAtDawn);
-    };
+    on staged,
+      :{
+        :useSkill(WhiteCloudsAtDawn);
+      };
     on switchActive {
       listenTo samePlayer;
       usage perRound, 2;

--- a/packages/data/src/characters/anemo/xiao.gts
+++ b/packages/data/src/characters/anemo/xiao.gts
@@ -145,9 +145,8 @@ define card {
   cost DiceType.Anemo, 3;
   cost DiceType.Energy, 2;
   talent Xiao {
-    on staged,
-      :{
-        :useSkill(BaneOfAllEvil);
-      };
+    on staged {
+      :useSkill(BaneOfAllEvil);
+    };
   };
 };

--- a/packages/data/src/characters/anemo/xiao.gts
+++ b/packages/data/src/characters/anemo/xiao.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 115042
@@ -149,8 +145,9 @@ define card {
   cost DiceType.Anemo, 3;
   cost DiceType.Energy, 2;
   talent Xiao {
-    on enter {
-      :useSkill(BaneOfAllEvil);
-    };
+    on staged,
+      :{
+        :useSkill(BaneOfAllEvil);
+      };
   };
 };

--- a/packages/data/src/characters/anemo/yumemizuki_mizuki.gts
+++ b/packages/data/src/characters/anemo/yumemizuki_mizuki.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import { ResistantForm } from "../../commons.gts";
 /**
  * @id 115142
@@ -148,9 +144,10 @@ define card {
   since "v6.0.0";
   cost DiceType.Anemo, 3;
   talent YumemizukiMizuki {
-    on enter {
-      :useSkill(AisaUtamakuraPilgrimage);
-    };
+    on staged,
+      :{
+        :useSkill(AisaUtamakuraPilgrimage);
+      };
     on increaseDamage {
       when :(
         :self.master.isActive() &&

--- a/packages/data/src/characters/anemo/yumemizuki_mizuki.gts
+++ b/packages/data/src/characters/anemo/yumemizuki_mizuki.gts
@@ -144,10 +144,9 @@ define card {
   since "v6.0.0";
   cost DiceType.Anemo, 3;
   talent YumemizukiMizuki {
-    on staged,
-      :{
-        :useSkill(AisaUtamakuraPilgrimage);
-      };
+    on staged {
+      :useSkill(AisaUtamakuraPilgrimage);
+    };
     on increaseDamage {
       when :(
         :self.master.isActive() &&

--- a/packages/data/src/characters/cryo/charlotte.gts
+++ b/packages/data/src/characters/cryo/charlotte.gts
@@ -129,10 +129,9 @@ define card {
   since "v4.5.0";
   cost DiceType.Cryo, 3;
   talent Charlotte {
-    on staged,
-      :{
-        :useSkill(FramingFreezingPointComposition);
-      };
+    on staged {
+      :useSkill(FramingFreezingPointComposition);
+    };
     on useSkill {
       when :(
         :e.isSkillType("normal") &&

--- a/packages/data/src/characters/cryo/charlotte.gts
+++ b/packages/data/src/characters/cryo/charlotte.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  Aura,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, Aura, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 111102
@@ -134,9 +129,10 @@ define card {
   since "v4.5.0";
   cost DiceType.Cryo, 3;
   talent Charlotte {
-    on enter {
-      :useSkill(FramingFreezingPointComposition);
-    };
+    on staged,
+      :{
+        :useSkill(FramingFreezingPointComposition);
+      };
     on useSkill {
       when :(
         :e.isSkillType("normal") &&

--- a/packages/data/src/characters/cryo/chongyun.gts
+++ b/packages/data/src/characters/cryo/chongyun.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 111042
@@ -157,8 +153,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Cryo, 3;
   talent Chongyun {
-    on enter {
-      :useSkill(ChonghuasLayeredFrost);
-    };
+    on staged,
+      :{
+        :useSkill(ChonghuasLayeredFrost);
+      };
   };
 };

--- a/packages/data/src/characters/cryo/chongyun.gts
+++ b/packages/data/src/characters/cryo/chongyun.gts
@@ -153,9 +153,8 @@ define card {
   since "v3.3.0";
   cost DiceType.Cryo, 3;
   talent Chongyun {
-    on staged,
-      :{
-        :useSkill(ChonghuasLayeredFrost);
-      };
+    on staged {
+      :useSkill(ChonghuasLayeredFrost);
+    };
   };
 };

--- a/packages/data/src/characters/cryo/cryo_hypostasis.gts
+++ b/packages/data/src/characters/cryo/cryo_hypostasis.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type StatusHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type StatusHandle } from "@gi-tcg/core/data";
 import { SheerCold } from "./la_signora.gts";
 
 /**
@@ -180,8 +175,9 @@ define card {
   since "v4.4.0";
   cost DiceType.Cryo, 1;
   talent CryoHypostasis, active {
-    on enter {
-      :characterStatus(CryoCrystalCore, :self.master);
-    };
+    on staged,
+      :{
+        :characterStatus(CryoCrystalCore, :self.master);
+      };
   };
 };

--- a/packages/data/src/characters/cryo/cryo_hypostasis.gts
+++ b/packages/data/src/characters/cryo/cryo_hypostasis.gts
@@ -175,9 +175,8 @@ define card {
   since "v4.4.0";
   cost DiceType.Cryo, 1;
   talent CryoHypostasis, active {
-    on staged,
-      :{
-        :characterStatus(CryoCrystalCore, :self.master);
-      };
+    on staged {
+      :characterStatus(CryoCrystalCore, :self.master);
+    };
   };
 };

--- a/packages/data/src/characters/cryo/diona.gts
+++ b/packages/data/src/characters/cryo/diona.gts
@@ -133,9 +133,8 @@ define card {
   since "v3.3.0";
   cost DiceType.Cryo, 3;
   talent Diona {
-    on staged,
-      :{
-        :useSkill(IcyPaws);
-      };
+    on staged {
+      :useSkill(IcyPaws);
+    };
   };
 };

--- a/packages/data/src/characters/cryo/diona.gts
+++ b/packages/data/src/characters/cryo/diona.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 111023
@@ -138,8 +133,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Cryo, 3;
   talent Diona {
-    on enter {
-      :useSkill(IcyPaws);
-    };
+    on staged,
+      :{
+        :useSkill(IcyPaws);
+      };
   };
 };

--- a/packages/data/src/characters/cryo/escoffier.gts
+++ b/packages/data/src/characters/cryo/escoffier.gts
@@ -263,9 +263,8 @@ define card {
   since "v6.2.0";
   cost DiceType.Cryo, 4;
   talent Escoffier {
-    on staged,
-      :{
-        :useSkill(LowtemperatureCooking);
-      };
+    on staged {
+      :useSkill(LowtemperatureCooking);
+    };
   };
 };

--- a/packages/data/src/characters/cryo/escoffier.gts
+++ b/packages/data/src/characters/cryo/escoffier.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 111151
@@ -268,8 +263,9 @@ define card {
   since "v6.2.0";
   cost DiceType.Cryo, 4;
   talent Escoffier {
-    on enter {
-      :useSkill(LowtemperatureCooking);
-    };
+    on staged,
+      :{
+        :useSkill(LowtemperatureCooking);
+      };
   };
 };

--- a/packages/data/src/characters/cryo/eula.gts
+++ b/packages/data/src/characters/cryo/eula.gts
@@ -148,9 +148,8 @@ define card {
   cost DiceType.Cryo, 3;
   cost DiceType.Energy, 2;
   talent Eula {
-    on staged,
-      :{
-        :useSkill(GlacialIllumination);
-      };
+    on staged {
+      :useSkill(GlacialIllumination);
+    };
   };
 };

--- a/packages/data/src/characters/cryo/eula.gts
+++ b/packages/data/src/characters/cryo/eula.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 111062
@@ -153,8 +148,9 @@ define card {
   cost DiceType.Cryo, 3;
   cost DiceType.Energy, 2;
   talent Eula {
-    on enter {
-      :useSkill(GlacialIllumination);
-    };
+    on staged,
+      :{
+        :useSkill(GlacialIllumination);
+      };
   };
 };

--- a/packages/data/src/characters/cryo/fatui_cryo_cicin_mage.gts
+++ b/packages/data/src/characters/cryo/fatui_cryo_cicin_mage.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SummonHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SummonHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 121011
@@ -162,9 +157,10 @@ define card {
   cost DiceType.Cryo, 3;
   talent FatuiCryoCicinMage {
     variable dealDamage, 0;
-    on enter {
-      :useSkill(MistySummons);
-    };
+    on staged,
+      :{
+        :useSkill(MistySummons);
+      };
     on useSkill {
       when :( :getVariable("dealDamage") );
       :damage(DamageType.Cryo, 2);

--- a/packages/data/src/characters/cryo/fatui_cryo_cicin_mage.gts
+++ b/packages/data/src/characters/cryo/fatui_cryo_cicin_mage.gts
@@ -157,10 +157,9 @@ define card {
   cost DiceType.Cryo, 3;
   talent FatuiCryoCicinMage {
     variable dealDamage, 0;
-    on staged,
-      :{
-        :useSkill(MistySummons);
-      };
+    on staged {
+      :useSkill(MistySummons);
+    };
     on useSkill {
       when :( :getVariable("dealDamage") );
       :damage(DamageType.Cryo, 2);

--- a/packages/data/src/characters/cryo/freminet.gts
+++ b/packages/data/src/characters/cryo/freminet.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 111121
@@ -166,9 +162,10 @@ define card {
   since "v5.0.0";
   cost DiceType.Cryo, 3;
   talent Freminet {
-    on enter {
-      :useSkill(PressurizedFloe);
-    };
+    on staged,
+      :{
+        :useSkill(PressurizedFloe);
+      };
     on useSkill {
       usage perRound, 2;
       :drawCards(1);

--- a/packages/data/src/characters/cryo/freminet.gts
+++ b/packages/data/src/characters/cryo/freminet.gts
@@ -162,10 +162,9 @@ define card {
   since "v5.0.0";
   cost DiceType.Cryo, 3;
   talent Freminet {
-    on staged,
-      :{
-        :useSkill(PressurizedFloe);
-      };
+    on staged {
+      :useSkill(PressurizedFloe);
+    };
     on useSkill {
       usage perRound, 2;
       :drawCards(1);

--- a/packages/data/src/characters/cryo/frost_operative.gts
+++ b/packages/data/src/characters/cryo/frost_operative.gts
@@ -139,9 +139,8 @@ define card {
   since "v4.8.0";
   cost DiceType.Cryo, 3;
   talent FrostOperative {
-    on staged,
-      :{
-        :useSkill(FrostyInterjection);
-      };
+    on staged {
+      :useSkill(FrostyInterjection);
+    };
   };
 };

--- a/packages/data/src/characters/cryo/frost_operative.gts
+++ b/packages/data/src/characters/cryo/frost_operative.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import { BondOfLife } from "../../commons.gts";
 
 /**
@@ -143,8 +139,9 @@ define card {
   since "v4.8.0";
   cost DiceType.Cryo, 3;
   talent FrostOperative {
-    on enter {
-      :useSkill(FrostyInterjection);
-    };
+    on staged,
+      :{
+        :useSkill(FrostyInterjection);
+      };
   };
 };

--- a/packages/data/src/characters/cryo/ganyu.gts
+++ b/packages/data/src/characters/cryo/ganyu.gts
@@ -158,9 +158,8 @@ define card {
   since "v3.3.0";
   cost DiceType.Cryo, 5;
   talent Ganyu {
-    on staged,
-      :{
-        :useSkill(FrostflakeArrow);
-      };
+    on staged {
+      :useSkill(FrostflakeArrow);
+    };
   };
 };

--- a/packages/data/src/characters/cryo/ganyu.gts
+++ b/packages/data/src/characters/cryo/ganyu.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 111011
@@ -162,8 +158,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Cryo, 5;
   talent Ganyu {
-    on enter {
-      :useSkill(FrostflakeArrow);
-    };
+    on staged,
+      :{
+        :useSkill(FrostflakeArrow);
+      };
   };
 };

--- a/packages/data/src/characters/cryo/kaeya.gts
+++ b/packages/data/src/characters/cryo/kaeya.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 111031
@@ -106,9 +101,10 @@ define card {
   since "v3.3.0";
   cost DiceType.Cryo, 3;
   talent Kaeya {
-    on enter {
-      :useSkill(Frostgnaw);
-    };
+    on staged,
+      :{
+        :useSkill(Frostgnaw);
+      };
     on useSkill {
       when :( :e.skill.definition.id === Frostgnaw );
       usage perRound, 1;

--- a/packages/data/src/characters/cryo/kaeya.gts
+++ b/packages/data/src/characters/cryo/kaeya.gts
@@ -101,10 +101,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Cryo, 3;
   talent Kaeya {
-    on staged,
-      :{
-        :useSkill(Frostgnaw);
-      };
+    on staged {
+      :useSkill(Frostgnaw);
+    };
     on useSkill {
       when :( :e.skill.definition.id === Frostgnaw );
       usage perRound, 1;

--- a/packages/data/src/characters/cryo/la_signora.gts
+++ b/packages/data/src/characters/cryo/la_signora.gts
@@ -222,9 +222,10 @@ define card {
   talent [LaSignora, CrimsonWitchOfEmbers], active {
     tags barrier;
     variable barrierUsage, 0; // no io hint for now
-    on enter {
-      :generateDice(:self.master.element(), 3);
-    };
+    on staged,
+      :{
+        :generateDice(:self.master.element(), 3);
+      };
     on decreaseDamaged {
       when :( :e.value >= 3 );
       usage perRound, 1;

--- a/packages/data/src/characters/cryo/la_signora.gts
+++ b/packages/data/src/characters/cryo/la_signora.gts
@@ -222,10 +222,9 @@ define card {
   talent [LaSignora, CrimsonWitchOfEmbers], active {
     tags barrier;
     variable barrierUsage, 0; // no io hint for now
-    on staged,
-      :{
-        :generateDice(:self.master.element(), 3);
-      };
+    on staged {
+      :generateDice(:self.master.element(), 3);
+    };
     on decreaseDamaged {
       when :( :e.value >= 3 );
       usage perRound, 1;

--- a/packages/data/src/characters/cryo/layla.gts
+++ b/packages/data/src/characters/cryo/layla.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 111093
@@ -149,8 +145,9 @@ define card {
   since "v4.3.0";
   cost DiceType.Cryo, 3;
   talent Layla {
-    on enter {
-      :useSkill(NightsOfFormalFocus);
-    };
+    on staged,
+      :{
+        :useSkill(NightsOfFormalFocus);
+      };
   };
 };

--- a/packages/data/src/characters/cryo/layla.gts
+++ b/packages/data/src/characters/cryo/layla.gts
@@ -145,9 +145,8 @@ define card {
   since "v4.3.0";
   cost DiceType.Cryo, 3;
   talent Layla {
-    on staged,
-      :{
-        :useSkill(NightsOfFormalFocus);
-      };
+    on staged {
+      :useSkill(NightsOfFormalFocus);
+    };
   };
 };

--- a/packages/data/src/characters/cryo/mika.gts
+++ b/packages/data/src/characters/cryo/mika.gts
@@ -220,9 +220,8 @@ define card {
   since "v6.4.0";
   cost DiceType.Cryo, 3;
   talent Mika {
-    on staged,
-      :{
-        :useSkill(StarfrostSwirl);
-      };
+    on staged {
+      :useSkill(StarfrostSwirl);
+    };
   };
 };

--- a/packages/data/src/characters/cryo/mika.gts
+++ b/packages/data/src/characters/cryo/mika.gts
@@ -220,8 +220,9 @@ define card {
   since "v6.4.0";
   cost DiceType.Cryo, 3;
   talent Mika {
-    on enter {
-      :useSkill(StarfrostSwirl);
-    };
+    on staged,
+      :{
+        :useSkill(StarfrostSwirl);
+      };
   };
 };

--- a/packages/data/src/characters/cryo/qiqi.gts
+++ b/packages/data/src/characters/cryo/qiqi.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 111081
@@ -172,8 +167,9 @@ define card {
   cost DiceType.Cryo, 4;
   cost DiceType.Energy, 3;
   talent Qiqi {
-    on enter {
-      :useSkill(AdeptusArtPreserverOfFortune);
-    };
+    on staged,
+      :{
+        :useSkill(AdeptusArtPreserverOfFortune);
+      };
   };
 };

--- a/packages/data/src/characters/cryo/qiqi.gts
+++ b/packages/data/src/characters/cryo/qiqi.gts
@@ -167,9 +167,8 @@ define card {
   cost DiceType.Cryo, 4;
   cost DiceType.Energy, 3;
   talent Qiqi {
-    on staged,
-      :{
-        :useSkill(AdeptusArtPreserverOfFortune);
-      };
+    on staged {
+      :useSkill(AdeptusArtPreserverOfFortune);
+    };
   };
 };

--- a/packages/data/src/characters/cryo/rosaria.gts
+++ b/packages/data/src/characters/cryo/rosaria.gts
@@ -13,10 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType } from "@gi-tcg/core/data";
 import { ChangingShifts } from "../../cards/event/other.gts";
 
 /**
@@ -165,9 +162,10 @@ define card {
   since "v5.2.0";
   cost DiceType.Cryo, 3;
   talent Rosaria {
-    on enter {
-      :useSkill(RavagingConfession);
-    };
+    on staged,
+      :{
+        :useSkill(RavagingConfession);
+      };
     on useSkill {
       when :( :e.skill.definition.id === RavagingConfession );
       :createHandCard(ChangingShifts);

--- a/packages/data/src/characters/cryo/rosaria.gts
+++ b/packages/data/src/characters/cryo/rosaria.gts
@@ -162,10 +162,9 @@ define card {
   since "v5.2.0";
   cost DiceType.Cryo, 3;
   talent Rosaria {
-    on staged,
-      :{
-        :useSkill(RavagingConfession);
-      };
+    on staged {
+      :useSkill(RavagingConfession);
+    };
     on useSkill {
       when :( :e.skill.definition.id === RavagingConfession );
       :createHandCard(ChangingShifts);

--- a/packages/data/src/characters/cryo/shenhe.gts
+++ b/packages/data/src/characters/cryo/shenhe.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 111073
@@ -176,8 +172,9 @@ define card {
   since "v3.7.0";
   cost DiceType.Cryo, 3;
   talent Shenhe {
-    on enter {
-      :useSkill(SpringSpiritSummoning);
-    };
+    on staged,
+      :{
+        :useSkill(SpringSpiritSummoning);
+      };
   };
 };

--- a/packages/data/src/characters/cryo/shenhe.gts
+++ b/packages/data/src/characters/cryo/shenhe.gts
@@ -172,9 +172,8 @@ define card {
   since "v3.7.0";
   cost DiceType.Cryo, 3;
   talent Shenhe {
-    on staged,
-      :{
-        :useSkill(SpringSpiritSummoning);
-      };
+    on staged {
+      :useSkill(SpringSpiritSummoning);
+    };
   };
 };

--- a/packages/data/src/characters/cryo/wayward_hermetic_spiritspeaker.gts
+++ b/packages/data/src/characters/cryo/wayward_hermetic_spiritspeaker.gts
@@ -346,9 +346,10 @@ define card {
   since "v6.7.0";
   cost DiceType.Cryo, 1;
   talent WaywardHermeticSpiritspeaker, none {
-    on enter {
-      :createHandCard(RadiantHues);
-    };
+    on staged,
+      :{
+        :createHandCard(RadiantHues);
+      };
     on playCard {
       when :( :e.card.definition.id === RadiantHues );
       usage perRound, 1;

--- a/packages/data/src/characters/cryo/wayward_hermetic_spiritspeaker.gts
+++ b/packages/data/src/characters/cryo/wayward_hermetic_spiritspeaker.gts
@@ -346,10 +346,9 @@ define card {
   since "v6.7.0";
   cost DiceType.Cryo, 1;
   talent WaywardHermeticSpiritspeaker, none {
-    on staged,
-      :{
-        :createHandCard(RadiantHues);
-      };
+    on staged {
+      :createHandCard(RadiantHues);
+    };
     on playCard {
       when :( :e.card.definition.id === RadiantHues );
       usage perRound, 1;

--- a/packages/data/src/characters/cryo/wriothesley.gts
+++ b/packages/data/src/characters/cryo/wriothesley.gts
@@ -193,10 +193,9 @@ define card {
   cost DiceType.Void, 2;
   talent Wriothesley {
     variable count, 0;
-    on staged,
-      :{
-        :useSkill(ForcefulFistsOfFrost);
-      };
+    on staged {
+      :useSkill(ForcefulFistsOfFrost);
+    };
     on damagedOrHealed {
       :addVariable("count", 1);
     };

--- a/packages/data/src/characters/cryo/wriothesley.gts
+++ b/packages/data/src/characters/cryo/wriothesley.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 111111
@@ -197,9 +193,10 @@ define card {
   cost DiceType.Void, 2;
   talent Wriothesley {
     variable count, 0;
-    on enter {
-      :useSkill(ForcefulFistsOfFrost);
-    };
+    on staged,
+      :{
+        :useSkill(ForcefulFistsOfFrost);
+      };
     on damagedOrHealed {
       :addVariable("count", 1);
     };

--- a/packages/data/src/characters/dendro/alhaitham.gts
+++ b/packages/data/src/characters/dendro/alhaitham.gts
@@ -139,9 +139,8 @@ define card {
   cost DiceType.Dendro, 3;
   cost DiceType.Energy, 2;
   talent Alhaitham {
-    on staged,
-      :{
-        :useSkill(ParticularFieldFettersOfPhenomena);
-      };
+    on staged {
+      :useSkill(ParticularFieldFettersOfPhenomena);
+    };
   };
 };

--- a/packages/data/src/characters/dendro/alhaitham.gts
+++ b/packages/data/src/characters/dendro/alhaitham.gts
@@ -13,10 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 117061
@@ -142,8 +139,9 @@ define card {
   cost DiceType.Dendro, 3;
   cost DiceType.Energy, 2;
   talent Alhaitham {
-    on enter {
-      :useSkill(ParticularFieldFettersOfPhenomena);
-    };
+    on staged,
+      :{
+        :useSkill(ParticularFieldFettersOfPhenomena);
+      };
   };
 };

--- a/packages/data/src/characters/dendro/baizhu.gts
+++ b/packages/data/src/characters/dendro/baizhu.gts
@@ -47,7 +47,7 @@ define summon {
 define combatStatus {
   id 117053 as SeamlessShield;
   shield 1;
-  defineSnippet :{
+  defineSnippet {
     :damage(DamageType.Dendro, 1);
     const active = :query($.my.active);
     if (!active) {

--- a/packages/data/src/characters/dendro/baizhu.gts
+++ b/packages/data/src/characters/dendro/baizhu.gts
@@ -156,9 +156,8 @@ define card {
   cost DiceType.Dendro, 4;
   cost DiceType.Energy, 2;
   talent Baizhu {
-    on staged,
-      :{
-        :useSkill(HolisticRevivification);
-      };
+    on staged {
+      :useSkill(HolisticRevivification);
+    };
   };
 };

--- a/packages/data/src/characters/dendro/baizhu.gts
+++ b/packages/data/src/characters/dendro/baizhu.gts
@@ -156,8 +156,9 @@ define card {
   cost DiceType.Dendro, 4;
   cost DiceType.Energy, 2;
   talent Baizhu {
-    on enter {
-      :useSkill(HolisticRevivification);
-    };
+    on staged,
+      :{
+        :useSkill(HolisticRevivification);
+      };
   };
 };

--- a/packages/data/src/characters/dendro/collei.gts
+++ b/packages/data/src/characters/dendro/collei.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 117011
@@ -142,8 +137,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Dendro, 3;
   talent Collei {
-    on enter {
-      :useSkill(FloralBrush);
-    };
+    on staged,
+      :{
+        :useSkill(FloralBrush);
+      };
   };
 };

--- a/packages/data/src/characters/dendro/collei.gts
+++ b/packages/data/src/characters/dendro/collei.gts
@@ -137,9 +137,8 @@ define card {
   since "v3.3.0";
   cost DiceType.Dendro, 3;
   talent Collei {
-    on staged,
-      :{
-        :useSkill(FloralBrush);
-      };
+    on staged {
+      :useSkill(FloralBrush);
+    };
   };
 };

--- a/packages/data/src/characters/dendro/consecrated_fanged_beast.gts
+++ b/packages/data/src/characters/dendro/consecrated_fanged_beast.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import {
   BonecrunchersEnergyBlock,
   BonecrunchersEnergyBlockCombatStatus,

--- a/packages/data/src/characters/dendro/eremite_floral_ringdancer.gts
+++ b/packages/data/src/characters/dendro/eremite_floral_ringdancer.gts
@@ -183,10 +183,9 @@ define card {
   since "v5.1.0";
   cost DiceType.Dendro, 3;
   talent EremiteFloralRingdancer {
-    on staged,
-      :{
-        :useSkill(SpiralingWhirl);
-      };
+    on staged {
+      :useSkill(SpiralingWhirl);
+    };
     on switchActive {
       when :(
         :e.switchInfo.to.hasTechnique()?.definition.id ===

--- a/packages/data/src/characters/dendro/eremite_floral_ringdancer.gts
+++ b/packages/data/src/characters/dendro/eremite_floral_ringdancer.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 127030
@@ -187,9 +183,10 @@ define card {
   since "v5.1.0";
   cost DiceType.Dendro, 3;
   talent EremiteFloralRingdancer {
-    on enter {
-      :useSkill(SpiralingWhirl);
-    };
+    on staged,
+      :{
+        :useSkill(SpiralingWhirl);
+      };
     on switchActive {
       when :(
         :e.switchInfo.to.hasTechnique()?.definition.id ===

--- a/packages/data/src/characters/dendro/gluttonous_yumkasaur_mountain_king.gts
+++ b/packages/data/src/characters/dendro/gluttonous_yumkasaur_mountain_king.gts
@@ -187,14 +187,13 @@ define card {
   since "v5.8.0";
   cost DiceType.Dendro, 1;
   talent GluttonousYumkasaurMountainKing, none {
-    on staged,
-      :{
-        :drawCards(1, { who: "opp" });
-        const [handCard] = :maxCostHands(1, { who: "opp" });
-        if (handCard) {
-          :stealHandCard(handCard);
-        }
-      };
+    on staged {
+      :drawCards(1, { who: "opp" });
+      const [handCard] = :maxCostHands(1, { who: "opp" });
+      if (handCard) {
+        :stealHandCard(handCard);
+      }
+    };
     on playCard {
       when :( !:isInInitialPile(:e.card) );
       usage perRound, 1;

--- a/packages/data/src/characters/dendro/gluttonous_yumkasaur_mountain_king.gts
+++ b/packages/data/src/characters/dendro/gluttonous_yumkasaur_mountain_king.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  customEvent,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, customEvent, DamageType, DiceType } from "@gi-tcg/core/data";
 import { Satiated } from "../../commons.gts";
 
 /**
@@ -192,13 +187,14 @@ define card {
   since "v5.8.0";
   cost DiceType.Dendro, 1;
   talent GluttonousYumkasaurMountainKing, none {
-    on enter {
-      :drawCards(1, { who: "opp" });
-      const [handCard] = :maxCostHands(1, { who: "opp" });
-      if (handCard) {
-        :stealHandCard(handCard);
-      }
-    };
+    on staged,
+      :{
+        :drawCards(1, { who: "opp" });
+        const [handCard] = :maxCostHands(1, { who: "opp" });
+        if (handCard) {
+          :stealHandCard(handCard);
+        }
+      };
     on playCard {
       when :( !:isInInitialPile(:e.card) );
       usage perRound, 1;

--- a/packages/data/src/characters/dendro/gluttonous_yumkasaur_mountain_king.gts
+++ b/packages/data/src/characters/dendro/gluttonous_yumkasaur_mountain_king.gts
@@ -110,7 +110,7 @@ const GluttonousRexTriggerFromTalent = customEvent(
 define skill {
   id 27044 as GluttonousRex01;
   skillType passive {
-    defineSnippet :{
+    defineSnippet {
       :abortPreview();
       const choice = :random([
         WellFedAndStrong,

--- a/packages/data/src/characters/dendro/guardian_of_apeps_oasis.gts
+++ b/packages/data/src/characters/dendro/guardian_of_apeps_oasis.gts
@@ -284,10 +284,9 @@ define card {
   since "v4.7.0";
   cost DiceType.Dendro, 2;
   talent GuardianOfApepsOasis, none {
-    on staged,
-      :{
-        :createPileCards(AwakenMyKindred, 4, "random");
-      };
+    on staged {
+      :createPileCards(AwakenMyKindred, 4, "random");
+    };
     on increaseDamage {
       when :(
         [

--- a/packages/data/src/characters/dendro/guardian_of_apeps_oasis.gts
+++ b/packages/data/src/characters/dendro/guardian_of_apeps_oasis.gts
@@ -284,9 +284,10 @@ define card {
   since "v4.7.0";
   cost DiceType.Dendro, 2;
   talent GuardianOfApepsOasis, none {
-    on enter {
-      :createPileCards(AwakenMyKindred, 4, "random");
-    };
+    on staged,
+      :{
+        :createPileCards(AwakenMyKindred, 4, "random");
+      };
     on increaseDamage {
       when :(
         [

--- a/packages/data/src/characters/dendro/jadeplume_terrorshroom.gts
+++ b/packages/data/src/characters/dendro/jadeplume_terrorshroom.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 127011
@@ -140,8 +136,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Dendro, 3;
   talent JadeplumeTerrorshroom {
-    on enter {
-      :useSkill(VolatileSporeCloud);
-    };
+    on staged,
+      :{
+        :useSkill(VolatileSporeCloud);
+      };
   };
 };

--- a/packages/data/src/characters/dendro/jadeplume_terrorshroom.gts
+++ b/packages/data/src/characters/dendro/jadeplume_terrorshroom.gts
@@ -136,9 +136,8 @@ define card {
   since "v3.3.0";
   cost DiceType.Dendro, 3;
   talent JadeplumeTerrorshroom {
-    on staged,
-      :{
-        :useSkill(VolatileSporeCloud);
-      };
+    on staged {
+      :useSkill(VolatileSporeCloud);
+    };
   };
 };

--- a/packages/data/src/characters/dendro/jadeplume_terrorshroom.gts
+++ b/packages/data/src/characters/dendro/jadeplume_terrorshroom.gts
@@ -25,11 +25,10 @@ import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 define status {
   id 127011 as RadicalVitalityStatus;
   variable vitality, 0;
-  defineSnippet addVitality,
-    :{
-      const max = :self.master.hasEquipment(ProliferatingSpores) ? 4 : 3;
-      :addVariableWithMax("vitality", 1, max);
-    };
+  defineSnippet addVitality {
+    const max = :self.master.hasEquipment(ProliferatingSpores) ? 4 : 3;
+    :addVariableWithMax("vitality", 1, max);
+  };
   on dealDamage {
     :callSnippet.addVitality();
   };

--- a/packages/data/src/characters/dendro/kaveh.gts
+++ b/packages/data/src/characters/dendro/kaveh.gts
@@ -173,10 +173,9 @@ define card {
   since "v4.7.0";
   cost DiceType.Dendro, 3;
   talent Kaveh {
-    on staged,
-      :{
-        :useSkill(ArtisticIngenuity);
-      };
+    on staged {
+      :useSkill(ArtisticIngenuity);
+    };
     on ShouldTriggerTalent {
       listenTo samePlayer;
       usage perRound, 1;

--- a/packages/data/src/characters/dendro/kaveh.gts
+++ b/packages/data/src/characters/dendro/kaveh.gts
@@ -173,9 +173,10 @@ define card {
   since "v4.7.0";
   cost DiceType.Dendro, 3;
   talent Kaveh {
-    on enter {
-      :useSkill(ArtisticIngenuity);
-    };
+    on staged,
+      :{
+        :useSkill(ArtisticIngenuity);
+      };
     on ShouldTriggerTalent {
       listenTo samePlayer;
       usage perRound, 1;

--- a/packages/data/src/characters/dendro/kinich.gts
+++ b/packages/data/src/characters/dendro/kinich.gts
@@ -27,7 +27,7 @@ define status {
   id 117091 as GrappleLink;
   since "v5.4.0";
   duration 2;
-  defineSnippet :{
+  defineSnippet {
     const nightsoul = :self.master.hasNightsoulsBlessing();
     if (
       nightsoul &&

--- a/packages/data/src/characters/dendro/kinich.gts
+++ b/packages/data/src/characters/dendro/kinich.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  Reaction,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, Reaction } from "@gi-tcg/core/data";
 
 /**
  * @id 117091

--- a/packages/data/src/characters/dendro/kirara.gts
+++ b/packages/data/src/characters/dendro/kirara.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 117073
@@ -150,9 +145,10 @@ define card {
   since "v4.5.0";
   cost DiceType.Dendro, 3;
   talent Kirara {
-    on enter {
-      :useSkill(MeowteorKick);
-    };
+    on staged,
+      :{
+        :useSkill(MeowteorKick);
+      };
     on deductOmniDiceSwitch {
       when :( :self.master.isActive() );
       usage perRound, 1;

--- a/packages/data/src/characters/dendro/kirara.gts
+++ b/packages/data/src/characters/dendro/kirara.gts
@@ -145,10 +145,9 @@ define card {
   since "v4.5.0";
   cost DiceType.Dendro, 3;
   talent Kirara {
-    on staged,
-      :{
-        :useSkill(MeowteorKick);
-      };
+    on staged {
+      :useSkill(MeowteorKick);
+    };
     on deductOmniDiceSwitch {
       when :( :self.master.isActive() );
       usage perRound, 1;

--- a/packages/data/src/characters/dendro/lauma.gts
+++ b/packages/data/src/characters/dendro/lauma.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  Reaction,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, Reaction } from "@gi-tcg/core/data";
 import { CostReduction } from "../../commons.gts";
 
 /**
@@ -187,9 +182,10 @@ define card {
   since "v6.6.0";
   cost DiceType.Dendro, 3;
   talent Lauma {
-    on enter {
-      :useSkill(RunoDawnlessRestOfKarsikko);
-    };
+    on staged,
+      :{
+        :useSkill(RunoDawnlessRestOfKarsikko);
+      };
     on dealReaction {
       when :(
         ([Reaction.Bloom, Reaction.LunarBloom] as Reaction[]).includes(:e.type)

--- a/packages/data/src/characters/dendro/lauma.gts
+++ b/packages/data/src/characters/dendro/lauma.gts
@@ -182,10 +182,9 @@ define card {
   since "v6.6.0";
   cost DiceType.Dendro, 3;
   talent Lauma {
-    on staged,
-      :{
-        :useSkill(RunoDawnlessRestOfKarsikko);
-      };
+    on staged {
+      :useSkill(RunoDawnlessRestOfKarsikko);
+    };
     on dealReaction {
       when :(
         ([Reaction.Bloom, Reaction.LunarBloom] as Reaction[]).includes(:e.type)

--- a/packages/data/src/characters/dendro/nahida.gts
+++ b/packages/data/src/characters/dendro/nahida.gts
@@ -232,9 +232,8 @@ define card {
   cost DiceType.Dendro, 3;
   cost DiceType.Energy, 2;
   talent Nahida {
-    on staged,
-      :{
-        :useSkill(IllusoryHeart);
-      };
+    on staged {
+      :useSkill(IllusoryHeart);
+    };
   };
 };

--- a/packages/data/src/characters/dendro/nahida.gts
+++ b/packages/data/src/characters/dendro/nahida.gts
@@ -94,9 +94,7 @@ define combatStatus {
   };
   on enter {
     when :(
-      :query(
-        $.my.character.has($.equipped.def(TheSeedOfStoredKnowledge)),
-      ) && // 装备有心识蕴藏之种
+      :query($.my.character.has($.equipped.def(TheSeedOfStoredKnowledge))) && // 装备有心识蕴藏之种
         :query($.my.character.includesDefeated.tag("electro")) // 我方队伍中存在雷元素
     );
     // 对方场上蕴种印的可用次数+1
@@ -123,9 +121,7 @@ define combatStatus {
   };
   on enter {
     when :(
-      :query(
-        $.my.character.has($.equipped.def(TheSeedOfStoredKnowledge)),
-      ) && // 装备有心识蕴藏之种
+      :query($.my.character.has($.equipped.def(TheSeedOfStoredKnowledge))) && // 装备有心识蕴藏之种
         :query($.my.character.includesDefeated.tag("electro")) // 我方队伍中存在雷元素
     );
     // 对方场上蕴种印的可用次数+1
@@ -236,8 +232,9 @@ define card {
   cost DiceType.Dendro, 3;
   cost DiceType.Energy, 2;
   talent Nahida {
-    on enter {
-      :useSkill(IllusoryHeart);
-    };
+    on staged,
+      :{
+        :useSkill(IllusoryHeart);
+      };
   };
 };

--- a/packages/data/src/characters/dendro/nefer.gts
+++ b/packages/data/src/characters/dendro/nefer.gts
@@ -189,11 +189,10 @@ define card {
           :attachCostReduction(card);
         }
       };
-    on staged,
-      :{
-        :createPileCards(SeedsOfDeceit, 3, "spaceAround");
-        :callSnippet.attachCostReductionToSeedsOfDeceit();
-      };
+    on staged {
+      :createPileCards(SeedsOfDeceit, 3, "spaceAround");
+      :callSnippet.attachCostReductionToSeedsOfDeceit();
+    };
     on skillDamage {
       when :( :e.via.definition.id === PhantasmPerformance );
       usage perRound, 2;

--- a/packages/data/src/characters/dendro/nefer.gts
+++ b/packages/data/src/characters/dendro/nefer.gts
@@ -189,10 +189,11 @@ define card {
           :attachCostReduction(card);
         }
       };
-    on enter {
-      :createPileCards(SeedsOfDeceit, 3, "spaceAround");
-      :callSnippet.attachCostReductionToSeedsOfDeceit();
-    };
+    on staged,
+      :{
+        :createPileCards(SeedsOfDeceit, 3, "spaceAround");
+        :callSnippet.attachCostReductionToSeedsOfDeceit();
+      };
     on skillDamage {
       when :( :e.via.definition.id === PhantasmPerformance );
       usage perRound, 2;

--- a/packages/data/src/characters/dendro/nefer.gts
+++ b/packages/data/src/characters/dendro/nefer.gts
@@ -182,13 +182,12 @@ define card {
   since "v6.7.0";
   cost DiceType.Dendro, 3;
   talent Nefer, none {
-    defineSnippet attachCostReductionToSeedsOfDeceit,
-      :{
-        const deceitCards = :queryAll($.my.pile.def(SeedsOfDeceit));
-        for (const card of deceitCards) {
-          :attachCostReduction(card);
-        }
-      };
+    defineSnippet attachCostReductionToSeedsOfDeceit {
+      const deceitCards = :queryAll($.my.pile.def(SeedsOfDeceit));
+      for (const card of deceitCards) {
+        :attachCostReduction(card);
+      }
+    };
     on staged {
       :createPileCards(SeedsOfDeceit, 3, "spaceAround");
       :callSnippet.attachCostReductionToSeedsOfDeceit();

--- a/packages/data/src/characters/dendro/tighnari.gts
+++ b/packages/data/src/characters/dendro/tighnari.gts
@@ -125,10 +125,9 @@ define card {
   since "v3.6.0";
   cost DiceType.Dendro, 3;
   talent Tighnari {
-    on staged,
-      :{
-        :useSkill(VijnanaphalaMine);
-      };
+    on staged {
+      :useSkill(VijnanaphalaMine);
+    };
     on deductVoidDiceSkill {
       when :(
         :self.master.hasStatus(VijnanaSuffusion) && :e.isChargedAttack()

--- a/packages/data/src/characters/dendro/tighnari.gts
+++ b/packages/data/src/characters/dendro/tighnari.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 117022
@@ -129,9 +125,10 @@ define card {
   since "v3.6.0";
   cost DiceType.Dendro, 3;
   talent Tighnari {
-    on enter {
-      :useSkill(VijnanaphalaMine);
-    };
+    on staged,
+      :{
+        :useSkill(VijnanaphalaMine);
+      };
     on deductVoidDiceSkill {
       when :(
         :self.master.hasStatus(VijnanaSuffusion) && :e.isChargedAttack()

--- a/packages/data/src/characters/dendro/yaoyao.gts
+++ b/packages/data/src/characters/dendro/yaoyao.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 117042
@@ -152,8 +147,9 @@ define card {
   since "v4.1.0";
   cost DiceType.Dendro, 3;
   talent Yaoyao {
-    on enter {
-      :useSkill(RaphanusSkyCluster);
-    };
+    on staged,
+      :{
+        :useSkill(RaphanusSkyCluster);
+      };
   };
 };

--- a/packages/data/src/characters/dendro/yaoyao.gts
+++ b/packages/data/src/characters/dendro/yaoyao.gts
@@ -147,9 +147,8 @@ define card {
   since "v4.1.0";
   cost DiceType.Dendro, 3;
   talent Yaoyao {
-    on staged,
-      :{
-        :useSkill(RaphanusSkyCluster);
-      };
+    on staged {
+      :useSkill(RaphanusSkyCluster);
+    };
   };
 };

--- a/packages/data/src/characters/electro/abyss_lector_violet_lightning.gts
+++ b/packages/data/src/characters/electro/abyss_lector_violet_lightning.gts
@@ -197,12 +197,11 @@ define card {
   since "v5.1.0";
   cost DiceType.Electro, 1;
   talent AbyssLectorVioletLightning, none {
-    on staged,
-      :{
-        :combatStatus(ChainLightningCascadeCombatStatus);
-        if (!:self.master.hasStatus(ElectricRebirth)) {
-          :query($.opp.active)?.loseEnergy(1);
-        }
-      };
+    on staged {
+      :combatStatus(ChainLightningCascadeCombatStatus);
+      if (!:self.master.hasStatus(ElectricRebirth)) {
+        :query($.opp.active)?.loseEnergy(1);
+      }
+    };
   };
 };

--- a/packages/data/src/characters/electro/abyss_lector_violet_lightning.gts
+++ b/packages/data/src/characters/electro/abyss_lector_violet_lightning.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  Aura,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, Aura, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 124063
@@ -202,11 +197,12 @@ define card {
   since "v5.1.0";
   cost DiceType.Electro, 1;
   talent AbyssLectorVioletLightning, none {
-    on enter {
-      :combatStatus(ChainLightningCascadeCombatStatus);
-      if (!:self.master.hasStatus(ElectricRebirth)) {
-        :query($.opp.active)?.loseEnergy(1);
-      }
-    };
+    on staged,
+      :{
+        :combatStatus(ChainLightningCascadeCombatStatus);
+        if (!:self.master.hasStatus(ElectricRebirth)) {
+          :query($.opp.active)?.loseEnergy(1);
+        }
+      };
   };
 };

--- a/packages/data/src/characters/electro/beidou.gts
+++ b/packages/data/src/characters/electro/beidou.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 114052
@@ -170,8 +166,9 @@ define card {
   since "v3.4.0";
   cost DiceType.Electro, 3;
   talent Beidou {
-    on enter {
-      :useSkill(Tidecaller);
-    };
+    on staged,
+      :{
+        :useSkill(Tidecaller);
+      };
   };
 };

--- a/packages/data/src/characters/electro/beidou.gts
+++ b/packages/data/src/characters/electro/beidou.gts
@@ -166,9 +166,8 @@ define card {
   since "v3.4.0";
   cost DiceType.Electro, 3;
   talent Beidou {
-    on staged,
-      :{
-        :useSkill(Tidecaller);
-      };
+    on staged {
+      :useSkill(Tidecaller);
+    };
   };
 };

--- a/packages/data/src/characters/electro/clorinde.gts
+++ b/packages/data/src/characters/electro/clorinde.gts
@@ -160,10 +160,9 @@ define card {
   since "v5.3.0";
   cost DiceType.Electro, 2;
   talent Clorinde {
-    on staged,
-      :{
-        :useSkill(HuntersVigil);
-      };
+    on staged {
+      :useSkill(HuntersVigil);
+    };
     on useSkill {
       when :( :hasPhaseReaction("my", (e) => e.relatedTo(DamageType.Electro)) );
       listenTo samePlayer;

--- a/packages/data/src/characters/electro/clorinde.gts
+++ b/packages/data/src/characters/electro/clorinde.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 import { BondOfLife } from "../../commons.gts";
 
 /**
@@ -165,9 +160,10 @@ define card {
   since "v5.3.0";
   cost DiceType.Electro, 2;
   talent Clorinde {
-    on enter {
-      :useSkill(HuntersVigil);
-    };
+    on staged,
+      :{
+        :useSkill(HuntersVigil);
+      };
     on useSkill {
       when :( :hasPhaseReaction("my", (e) => e.relatedTo(DamageType.Electro)) );
       listenTo samePlayer;

--- a/packages/data/src/characters/electro/consecrated_scorpion.gts
+++ b/packages/data/src/characters/electro/consecrated_scorpion.gts
@@ -131,10 +131,9 @@ define card {
   since "v4.7.0";
   cost DiceType.Electro, 1;
   talent ConsecratedScorpion, none {
-    on staged,
-      :{
-        :createHandCard(BonecrunchersEnergyBlock);
-      };
+    on staged {
+      :createHandCard(BonecrunchersEnergyBlock);
+    };
     on playCard {
       when :( :e.card.definition.id === BonecrunchersEnergyBlock );
       :drawCards(1);

--- a/packages/data/src/characters/electro/consecrated_scorpion.gts
+++ b/packages/data/src/characters/electro/consecrated_scorpion.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import { BonecrunchersEnergyBlock } from "../../cards/event/other.gts";
 
 /**
@@ -135,9 +131,10 @@ define card {
   since "v4.7.0";
   cost DiceType.Electro, 1;
   talent ConsecratedScorpion, none {
-    on enter {
-      :createHandCard(BonecrunchersEnergyBlock);
-    };
+    on staged,
+      :{
+        :createHandCard(BonecrunchersEnergyBlock);
+      };
     on playCard {
       when :( :e.card.definition.id === BonecrunchersEnergyBlock );
       :drawCards(1);

--- a/packages/data/src/characters/electro/cyno.gts
+++ b/packages/data/src/characters/electro/cyno.gts
@@ -13,10 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 114041
@@ -145,9 +142,10 @@ define card {
   since "v3.3.0";
   cost DiceType.Electro, 3;
   talent Cyno {
-    on enter {
-      :useSkill(SecretRiteChasmicSoulfarer);
-    };
+    on staged,
+      :{
+        :useSkill(SecretRiteChasmicSoulfarer);
+      };
     on increaseSkillDamage {
       when :{
         const status = :self.master.hasStatus(PactswornPathclearer)!;

--- a/packages/data/src/characters/electro/cyno.gts
+++ b/packages/data/src/characters/electro/cyno.gts
@@ -142,10 +142,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Electro, 3;
   talent Cyno {
-    on staged,
-      :{
-        :useSkill(SecretRiteChasmicSoulfarer);
-      };
+    on staged {
+      :useSkill(SecretRiteChasmicSoulfarer);
+    };
     on increaseSkillDamage {
       when :{
         const status = :self.master.hasStatus(PactswornPathclearer)!;

--- a/packages/data/src/characters/electro/dori.gts
+++ b/packages/data/src/characters/electro/dori.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 114101
@@ -161,8 +156,9 @@ define card {
   cost DiceType.Electro, 3;
   cost DiceType.Energy, 2;
   talent Dori {
-    on enter {
-      :useSkill(AlcazarzaraysExactitude);
-    };
+    on staged,
+      :{
+        :useSkill(AlcazarzaraysExactitude);
+      };
   };
 };

--- a/packages/data/src/characters/electro/dori.gts
+++ b/packages/data/src/characters/electro/dori.gts
@@ -156,9 +156,8 @@ define card {
   cost DiceType.Electro, 3;
   cost DiceType.Energy, 2;
   talent Dori {
-    on staged,
-      :{
-        :useSkill(AlcazarzaraysExactitude);
-      };
+    on staged {
+      :useSkill(AlcazarzaraysExactitude);
+    };
   };
 };

--- a/packages/data/src/characters/electro/electro_hypostasis.gts
+++ b/packages/data/src/characters/electro/electro_hypostasis.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 124013

--- a/packages/data/src/characters/electro/fatui_electro_cicin_mage.gts
+++ b/packages/data/src/characters/electro/fatui_electro_cicin_mage.gts
@@ -193,9 +193,8 @@ define card {
   since "v4.5.0";
   cost DiceType.Electro, 3;
   talent FatuiElectroCicinMage {
-    on staged,
-      :{
-        :useSkill(MistyCall);
-      };
+    on staged {
+      :useSkill(MistyCall);
+    };
   };
 };

--- a/packages/data/src/characters/electro/fatui_electro_cicin_mage.gts
+++ b/packages/data/src/characters/electro/fatui_electro_cicin_mage.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 124044
@@ -198,8 +193,9 @@ define card {
   since "v4.5.0";
   cost DiceType.Electro, 3;
   talent FatuiElectroCicinMage {
-    on enter {
-      :useSkill(MistyCall);
-    };
+    on staged,
+      :{
+        :useSkill(MistyCall);
+      };
   };
 };

--- a/packages/data/src/characters/electro/fischl.gts
+++ b/packages/data/src/characters/electro/fischl.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 114012
@@ -139,8 +134,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Electro, 3;
   talent Fischl {
-    on enter {
-      :useSkill(Nightrider);
-    };
+    on staged,
+      :{
+        :useSkill(Nightrider);
+      };
   };
 };

--- a/packages/data/src/characters/electro/fischl.gts
+++ b/packages/data/src/characters/electro/fischl.gts
@@ -134,9 +134,8 @@ define card {
   since "v3.3.0";
   cost DiceType.Electro, 3;
   talent Fischl {
-    on staged,
-      :{
-        :useSkill(Nightrider);
-      };
+    on staged {
+      :useSkill(Nightrider);
+    };
   };
 };

--- a/packages/data/src/characters/electro/flins.gts
+++ b/packages/data/src/characters/electro/flins.gts
@@ -207,10 +207,9 @@ define card {
   since "v6.6.0";
   cost DiceType.Electro, 1;
   talent Flins, none {
-    on staged,
-      :{
-        :gainEnergy(1, :self.master);
-      };
+    on staged {
+      :gainEnergy(1, :self.master);
+    };
     on dealReaction {
       when :( :e.type === Reaction.LunarElectroCharged );
       listenTo samePlayer;

--- a/packages/data/src/characters/electro/flins.gts
+++ b/packages/data/src/characters/electro/flins.gts
@@ -207,9 +207,10 @@ define card {
   since "v6.6.0";
   cost DiceType.Electro, 1;
   talent Flins, none {
-    on enter {
-      :gainEnergy(1, :self.master);
-    };
+    on staged,
+      :{
+        :gainEnergy(1, :self.master);
+      };
     on dealReaction {
       when :( :e.type === Reaction.LunarElectroCharged );
       listenTo samePlayer;

--- a/packages/data/src/characters/electro/iansan.gts
+++ b/packages/data/src/characters/electro/iansan.gts
@@ -117,7 +117,7 @@ define skill {
   skillType passive {
     variable switchCount, 0;
     variable gainNightsoulPassiveUsagePerRound, 3;
-    defineSnippet :{
+    defineSnippet {
       const nightsoul = :self.hasNightsoulsBlessing();
       if (!nightsoul) {
         return;

--- a/packages/data/src/characters/electro/iansan.gts
+++ b/packages/data/src/characters/electro/iansan.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 import { AgileSwitch } from "../../commons.gts";
 
 /**
@@ -227,8 +222,9 @@ define card {
   cost DiceType.Electro, 3;
   cost DiceType.Energy, 2;
   talent Iansan {
-    on enter {
-      :useSkill(TheThreePrinciplesOfPower);
-    };
+    on staged,
+      :{
+        :useSkill(TheThreePrinciplesOfPower);
+      };
   };
 };

--- a/packages/data/src/characters/electro/iansan.gts
+++ b/packages/data/src/characters/electro/iansan.gts
@@ -222,9 +222,8 @@ define card {
   cost DiceType.Electro, 3;
   cost DiceType.Energy, 2;
   talent Iansan {
-    on staged,
-      :{
-        :useSkill(TheThreePrinciplesOfPower);
-      };
+    on staged {
+      :useSkill(TheThreePrinciplesOfPower);
+    };
   };
 };

--- a/packages/data/src/characters/electro/ineffa.gts
+++ b/packages/data/src/characters/electro/ineffa.gts
@@ -146,15 +146,14 @@ define card {
   since "v6.4.0";
   cost DiceType.Electro, 1;
   talent Ineffa, none {
-    on staged,
-      :{
-        for (let i = 0; i < 2; i++) {
-          const target = :random(:oppPlayer.hands);
-          if (target) {
-            :attach(Conductive, target);
-          }
+    on staged {
+      for (let i = 0; i < 2; i++) {
+        const target = :random(:oppPlayer.hands);
+        if (target) {
+          :attach(Conductive, target);
         }
-      };
+      }
+    };
     on dealReaction {
       when :( :e.type === Reaction.LunarElectroCharged );
       listenTo samePlayer;

--- a/packages/data/src/characters/electro/ineffa.gts
+++ b/packages/data/src/characters/electro/ineffa.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-  Reaction,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType, Reaction } from "@gi-tcg/core/data";
 import { Conductive, NoTuningAllowed, Shield } from "../../commons.gts";
 import type { EntityType } from "@gi-tcg/core";
 
@@ -150,14 +146,15 @@ define card {
   since "v6.4.0";
   cost DiceType.Electro, 1;
   talent Ineffa, none {
-    on enter {
-      for (let i = 0; i < 2; i++) {
-        const target = :random(:oppPlayer.hands);
-        if (target) {
-          :attach(Conductive, target);
+    on staged,
+      :{
+        for (let i = 0; i < 2; i++) {
+          const target = :random(:oppPlayer.hands);
+          if (target) {
+            :attach(Conductive, target);
+          }
         }
-      }
-    };
+      };
     on dealReaction {
       when :( :e.type === Reaction.LunarElectroCharged );
       listenTo samePlayer;

--- a/packages/data/src/characters/electro/keqing.gts
+++ b/packages/data/src/characters/electro/keqing.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 114034
@@ -166,8 +162,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Electro, 3;
   talent Keqing {
-    on enter {
-      :useSkill(StellarRestoration);
-    };
+    on staged,
+      :{
+        :useSkill(StellarRestoration);
+      };
   };
 };

--- a/packages/data/src/characters/electro/keqing.gts
+++ b/packages/data/src/characters/electro/keqing.gts
@@ -162,9 +162,8 @@ define card {
   since "v3.3.0";
   cost DiceType.Electro, 3;
   talent Keqing {
-    on staged,
-      :{
-        :useSkill(StellarRestoration);
-      };
+    on staged {
+      :useSkill(StellarRestoration);
+    };
   };
 };

--- a/packages/data/src/characters/electro/kujou_sara.gts
+++ b/packages/data/src/characters/electro/kujou_sara.gts
@@ -140,9 +140,8 @@ define card {
   since "v3.5.0";
   cost DiceType.Electro, 3;
   talent KujouSara {
-    on staged,
-      :{
-        :useSkill(TenguStormcall);
-      };
+    on staged {
+      :useSkill(TenguStormcall);
+    };
   };
 };

--- a/packages/data/src/characters/electro/kujou_sara.gts
+++ b/packages/data/src/characters/electro/kujou_sara.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  type SkillHandle,
-  $,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { DamageType, type SkillHandle, $, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 114063
@@ -145,8 +140,9 @@ define card {
   since "v3.5.0";
   cost DiceType.Electro, 3;
   talent KujouSara {
-    on enter {
-      :useSkill(TenguStormcall);
-    };
+    on staged,
+      :{
+        :useSkill(TenguStormcall);
+      };
   };
 };

--- a/packages/data/src/characters/electro/kuki_shinobu.gts
+++ b/packages/data/src/characters/electro/kuki_shinobu.gts
@@ -108,10 +108,9 @@ define card {
   cost DiceType.Electro, 4;
   cost DiceType.Energy, 2;
   talent KukiShinobu {
-    on staged,
-      :{
-        :useSkill(GyoeiNarukamiKariyamaRite);
-      };
+    on staged {
+      :useSkill(GyoeiNarukamiKariyamaRite);
+    };
     on beforeDefeated {
       usage perRound, 1;
       :immune(1);

--- a/packages/data/src/characters/electro/kuki_shinobu.gts
+++ b/packages/data/src/characters/electro/kuki_shinobu.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 114111
@@ -112,9 +108,10 @@ define card {
   cost DiceType.Electro, 4;
   cost DiceType.Energy, 2;
   talent KukiShinobu {
-    on enter {
-      :useSkill(GyoeiNarukamiKariyamaRite);
-    };
+    on staged,
+      :{
+        :useSkill(GyoeiNarukamiKariyamaRite);
+      };
     on beforeDefeated {
       usage perRound, 1;
       :immune(1);

--- a/packages/data/src/characters/electro/lisa.gts
+++ b/packages/data/src/characters/electro/lisa.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-  $,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType, $, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 114092

--- a/packages/data/src/characters/electro/millennial_pearl_seahorse.gts
+++ b/packages/data/src/characters/electro/millennial_pearl_seahorse.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 124031
@@ -197,17 +193,18 @@ define card {
   id 224031 as PearlSolidification;
   since "v4.4.0";
   talent MillennialPearlSeahorse, active {
-    on enter {
-      const exists = :self.master.hasStatus(FontemerPearl);
-      if (exists) {
-        exists.addVariable("usage", 1);
-      } else {
-        :characterStatus(FontemerPearl, :self.master, {
-          overrideVariables: {
-            usage: 1,
-          },
-        });
-      }
-    };
+    on staged,
+      :{
+        const exists = :self.master.hasStatus(FontemerPearl);
+        if (exists) {
+          exists.addVariable("usage", 1);
+        } else {
+          :characterStatus(FontemerPearl, :self.master, {
+            overrideVariables: {
+              usage: 1,
+            },
+          });
+        }
+      };
   };
 };

--- a/packages/data/src/characters/electro/millennial_pearl_seahorse.gts
+++ b/packages/data/src/characters/electro/millennial_pearl_seahorse.gts
@@ -193,18 +193,17 @@ define card {
   id 224031 as PearlSolidification;
   since "v4.4.0";
   talent MillennialPearlSeahorse, active {
-    on staged,
-      :{
-        const exists = :self.master.hasStatus(FontemerPearl);
-        if (exists) {
-          exists.addVariable("usage", 1);
-        } else {
-          :characterStatus(FontemerPearl, :self.master, {
-            overrideVariables: {
-              usage: 1,
-            },
-          });
-        }
-      };
+    on staged {
+      const exists = :self.master.hasStatus(FontemerPearl);
+      if (exists) {
+        exists.addVariable("usage", 1);
+      } else {
+        :characterStatus(FontemerPearl, :self.master, {
+          overrideVariables: {
+            usage: 1,
+          },
+        });
+      }
+    };
   };
 };

--- a/packages/data/src/characters/electro/ororon.gts
+++ b/packages/data/src/characters/electro/ororon.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  Reaction,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, Reaction } from "@gi-tcg/core/data";
 
 /**
  * @id 114161

--- a/packages/data/src/characters/electro/raiden_shogun.gts
+++ b/packages/data/src/characters/electro/raiden_shogun.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 114071
@@ -160,8 +156,9 @@ define card {
   cost DiceType.Electro, 3;
   cost DiceType.Energy, 2;
   talent RaidenShogun {
-    on enter {
-      :useSkill(SecretArtMusouShinsetsu);
-    };
+    on staged,
+      :{
+        :useSkill(SecretArtMusouShinsetsu);
+      };
   };
 };

--- a/packages/data/src/characters/electro/raiden_shogun.gts
+++ b/packages/data/src/characters/electro/raiden_shogun.gts
@@ -156,9 +156,8 @@ define card {
   cost DiceType.Electro, 3;
   cost DiceType.Energy, 2;
   talent RaidenShogun {
-    on staged,
-      :{
-        :useSkill(SecretArtMusouShinsetsu);
-      };
+    on staged {
+      :useSkill(SecretArtMusouShinsetsu);
+    };
   };
 };

--- a/packages/data/src/characters/electro/razor.gts
+++ b/packages/data/src/characters/electro/razor.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 114021
@@ -107,9 +103,10 @@ define card {
   since "v3.3.0";
   cost DiceType.Electro, 3;
   talent Razor {
-    on enter {
-      :useSkill(ClawAndThunder);
-    };
+    on staged,
+      :{
+        :useSkill(ClawAndThunder);
+      };
     on useSkill {
       when :( :e.skill.definition.id === ClawAndThunder );
       usage perRound, 1;

--- a/packages/data/src/characters/electro/razor.gts
+++ b/packages/data/src/characters/electro/razor.gts
@@ -103,10 +103,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Electro, 3;
   talent Razor {
-    on staged,
-      :{
-        :useSkill(ClawAndThunder);
-      };
+    on staged {
+      :useSkill(ClawAndThunder);
+    };
     on useSkill {
       when :( :e.skill.definition.id === ClawAndThunder );
       usage perRound, 1;

--- a/packages/data/src/characters/electro/sethos.gts
+++ b/packages/data/src/characters/electro/sethos.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  customEvent,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, customEvent, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 114131
@@ -171,9 +166,10 @@ define card {
   since "v5.6.0";
   cost DiceType.Electro, 1;
   talent Sethos, none {
-    on enter {
-      :gainEnergy(1, :self.master);
-    };
+    on staged,
+      :{
+        :gainEnergy(1, :self.master);
+      };
     on EnergyLost {
       usage perRound, 1;
       :gainEnergy(1, :self.master);

--- a/packages/data/src/characters/electro/sethos.gts
+++ b/packages/data/src/characters/electro/sethos.gts
@@ -166,10 +166,9 @@ define card {
   since "v5.6.0";
   cost DiceType.Electro, 1;
   talent Sethos, none {
-    on staged,
-      :{
-        :gainEnergy(1, :self.master);
-      };
+    on staged {
+      :gainEnergy(1, :self.master);
+    };
     on EnergyLost {
       usage perRound, 1;
       :gainEnergy(1, :self.master);

--- a/packages/data/src/characters/electro/thunder_manifestation.gts
+++ b/packages/data/src/characters/electro/thunder_manifestation.gts
@@ -196,9 +196,10 @@ define card {
   since "v4.3.0";
   cost DiceType.Electro, 3;
   talent ThunderManifestation {
-    on enter {
-      :useSkill(StrifefulLightning);
-    };
+    on staged,
+      :{
+        :useSkill(StrifefulLightning);
+      };
     on TalentShouldDrawCard {
       listenTo all;
       usage perRound, 1;

--- a/packages/data/src/characters/electro/thunder_manifestation.gts
+++ b/packages/data/src/characters/electro/thunder_manifestation.gts
@@ -196,10 +196,9 @@ define card {
   since "v4.3.0";
   cost DiceType.Electro, 3;
   talent ThunderManifestation {
-    on staged,
-      :{
-        :useSkill(StrifefulLightning);
-      };
+    on staged {
+      :useSkill(StrifefulLightning);
+    };
     on TalentShouldDrawCard {
       listenTo all;
       usage perRound, 1;

--- a/packages/data/src/characters/electro/yae_miko.gts
+++ b/packages/data/src/characters/electro/yae_miko.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 114081
@@ -159,8 +155,9 @@ define card {
   cost DiceType.Electro, 3;
   cost DiceType.Energy, 2;
   talent YaeMiko {
-    on enter {
-      :useSkill(GreatSecretArtTenkoKenshin);
-    };
+    on staged,
+      :{
+        :useSkill(GreatSecretArtTenkoKenshin);
+      };
   };
 };

--- a/packages/data/src/characters/electro/yae_miko.gts
+++ b/packages/data/src/characters/electro/yae_miko.gts
@@ -155,9 +155,8 @@ define card {
   cost DiceType.Electro, 3;
   cost DiceType.Energy, 2;
   talent YaeMiko {
-    on staged,
-      :{
-        :useSkill(GreatSecretArtTenkoKenshin);
-      };
+    on staged {
+      :useSkill(GreatSecretArtTenkoKenshin);
+    };
   };
 };

--- a/packages/data/src/characters/geo/albedo.gts
+++ b/packages/data/src/characters/geo/albedo.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 116041
@@ -116,9 +112,10 @@ define card {
   since "v4.0.0";
   cost DiceType.Geo, 3;
   talent Albedo {
-    on enter {
-      :useSkill(AbiogenesisSolarIsotoma);
-    };
+    on staged,
+      :{
+        :useSkill(AbiogenesisSolarIsotoma);
+      };
     on deductVoidDiceSkill {
       when :( :query($.my.summon.def(SolarIsotoma)) && :e.isPlungingAttack() );
       listenTo samePlayer;

--- a/packages/data/src/characters/geo/albedo.gts
+++ b/packages/data/src/characters/geo/albedo.gts
@@ -112,10 +112,9 @@ define card {
   since "v4.0.0";
   cost DiceType.Geo, 3;
   talent Albedo {
-    on staged,
-      :{
-        :useSkill(AbiogenesisSolarIsotoma);
-      };
+    on staged {
+      :useSkill(AbiogenesisSolarIsotoma);
+    };
     on deductVoidDiceSkill {
       when :( :query($.my.summon.def(SolarIsotoma)) && :e.isPlungingAttack() );
       listenTo samePlayer;

--- a/packages/data/src/characters/geo/arataki_itto.gts
+++ b/packages/data/src/characters/geo/arataki_itto.gts
@@ -184,9 +184,8 @@ define card {
   cost DiceType.Geo, 1;
   cost DiceType.Void, 2;
   talent AratakiItto {
-    on staged,
-      :{
-        :useSkill(FightClubLegend);
-      };
+    on staged {
+      :useSkill(FightClubLegend);
+    };
   };
 };

--- a/packages/data/src/characters/geo/arataki_itto.gts
+++ b/packages/data/src/characters/geo/arataki_itto.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SummonHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SummonHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 116054
@@ -189,8 +184,9 @@ define card {
   cost DiceType.Geo, 1;
   cost DiceType.Void, 2;
   talent AratakiItto {
-    on enter {
-      :useSkill(FightClubLegend);
-    };
+    on staged,
+      :{
+        :useSkill(FightClubLegend);
+      };
   };
 };

--- a/packages/data/src/characters/geo/black_serpent_knight_rockbreaker_ax.gts
+++ b/packages/data/src/characters/geo/black_serpent_knight_rockbreaker_ax.gts
@@ -216,10 +216,9 @@ define card {
   since "v6.2.0";
   cost DiceType.Geo, 1;
   talent BlackSerpentKnightRockbreakerAx {
-    on staged,
-      :{
-        :apply(DamageType.Geo, :self.master);
-      };
+    on staged {
+      :apply(DamageType.Geo, :self.master);
+    };
     on actionPhase {
       :apply(DamageType.Geo, :self.master);
     };

--- a/packages/data/src/characters/geo/black_serpent_knight_rockbreaker_ax.gts
+++ b/packages/data/src/characters/geo/black_serpent_knight_rockbreaker_ax.gts
@@ -216,9 +216,10 @@ define card {
   since "v6.2.0";
   cost DiceType.Geo, 1;
   talent BlackSerpentKnightRockbreakerAx {
-    on enter {
-      :apply(DamageType.Geo, :self.master);
-    };
+    on staged,
+      :{
+        :apply(DamageType.Geo, :self.master);
+      };
     on actionPhase {
       :apply(DamageType.Geo, :self.master);
     };

--- a/packages/data/src/characters/geo/chiori.gts
+++ b/packages/data/src/characters/geo/chiori.gts
@@ -276,8 +276,9 @@ define card {
   since "v5.1.0";
   cost DiceType.Geo, 4;
   talent Chiori {
-    on enter {
-      :useSkill(FlutteringHasode);
-    };
+    on staged,
+      :{
+        :useSkill(FlutteringHasode);
+      };
   };
 };

--- a/packages/data/src/characters/geo/chiori.gts
+++ b/packages/data/src/characters/geo/chiori.gts
@@ -276,9 +276,8 @@ define card {
   since "v5.1.0";
   cost DiceType.Geo, 4;
   talent Chiori {
-    on staged,
-      :{
-        :useSkill(FlutteringHasode);
-      };
+    on staged {
+      :useSkill(FlutteringHasode);
+    };
   };
 };

--- a/packages/data/src/characters/geo/experimental_field_generator.gts
+++ b/packages/data/src/characters/geo/experimental_field_generator.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 import { EfficientSwitch } from "../../commons.gts";
 
 /**

--- a/packages/data/src/characters/geo/golden_wolflord.gts
+++ b/packages/data/src/characters/geo/golden_wolflord.gts
@@ -146,9 +146,8 @@ define card {
   since "v5.2.0";
   cost DiceType.Geo, 3;
   talent GoldenWolflord {
-    on staged,
-      :{
-        :useSkill(HowlingRiftcall);
-      };
+    on staged {
+      :useSkill(HowlingRiftcall);
+    };
   };
 };

--- a/packages/data/src/characters/geo/golden_wolflord.gts
+++ b/packages/data/src/characters/geo/golden_wolflord.gts
@@ -33,8 +33,7 @@ define status {
   since "v5.2.0";
   on endPhase {
     when :(
-      :query($.opp.equipped.def(BeastlyCorrosion)) ||
-        !:self.master.isActive()
+      :query($.opp.equipped.def(BeastlyCorrosion)) || !:self.master.isActive()
     );
     usage 1 {
       append 5;
@@ -147,8 +146,9 @@ define card {
   since "v5.2.0";
   cost DiceType.Geo, 3;
   talent GoldenWolflord {
-    on enter {
-      :useSkill(HowlingRiftcall);
-    };
+    on staged,
+      :{
+        :useSkill(HowlingRiftcall);
+      };
   };
 };

--- a/packages/data/src/characters/geo/gorou.gts
+++ b/packages/data/src/characters/geo/gorou.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import { Crystallize } from "../../commons.gts";
 
 /**
@@ -132,9 +128,10 @@ define card {
   since "v4.3.0";
   cost DiceType.Geo, 3;
   talent Gorou {
-    on enter {
-      :useSkill(InuzakaAllroundDefense);
-    };
+    on staged,
+      :{
+        :useSkill(InuzakaAllroundDefense);
+      };
     on skillDamage {
       when :(
         :e.type === DamageType.Geo &&

--- a/packages/data/src/characters/geo/gorou.gts
+++ b/packages/data/src/characters/geo/gorou.gts
@@ -128,10 +128,9 @@ define card {
   since "v4.3.0";
   cost DiceType.Geo, 3;
   talent Gorou {
-    on staged,
-      :{
-        :useSkill(InuzakaAllroundDefense);
-      };
+    on staged {
+      :useSkill(InuzakaAllroundDefense);
+    };
     on skillDamage {
       when :(
         :e.type === DamageType.Geo &&

--- a/packages/data/src/characters/geo/kachina.gts
+++ b/packages/data/src/characters/geo/kachina.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  customEvent,
-  DiceType,
-  $,
-} from "@gi-tcg/core/data";
+import { DamageType, customEvent, DiceType, $ } from "@gi-tcg/core/data";
 
 export const TurboTwirlyTriggered = customEvent("kachina/turboTwirlyTriggered");
 

--- a/packages/data/src/characters/geo/navia.gts
+++ b/packages/data/src/characters/geo/navia.gts
@@ -173,10 +173,9 @@ define card {
   since "v4.8.0";
   cost DiceType.Geo, 3;
   talent Navia {
-    on staged,
-      :{
-        :useSkill(CeremonialCrystalshot);
-      };
+    on staged {
+      :useSkill(CeremonialCrystalshot);
+    };
     on useSkill {
       usage perRound, 1;
       :drawCards(2, { withDefinition: CrystalShrapnel });

--- a/packages/data/src/characters/geo/navia.gts
+++ b/packages/data/src/characters/geo/navia.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  Reaction,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, Reaction } from "@gi-tcg/core/data";
 
 /**
  * @id 116081
@@ -178,9 +173,10 @@ define card {
   since "v4.8.0";
   cost DiceType.Geo, 3;
   talent Navia {
-    on enter {
-      :useSkill(CeremonialCrystalshot);
-    };
+    on staged,
+      :{
+        :useSkill(CeremonialCrystalshot);
+      };
     on useSkill {
       usage perRound, 1;
       :drawCards(2, { withDefinition: CrystalShrapnel });

--- a/packages/data/src/characters/geo/ningguang.gts
+++ b/packages/data/src/characters/geo/ningguang.gts
@@ -37,8 +37,7 @@ define combatStatus {
   };
   on increaseDamage {
     when :(
-      :e.type === DamageType.Geo &&
-        :query($.my.equipped.def(StrategicReserve))
+      :e.type === DamageType.Geo && :query($.my.equipped.def(StrategicReserve))
     );
     listenTo samePlayer;
     :e.increaseDamage(1);
@@ -120,8 +119,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Geo, 3;
   talent Ningguang {
-    on enter {
-      :useSkill(JadeScreen);
-    };
+    on staged,
+      :{
+        :useSkill(JadeScreen);
+      };
   };
 };

--- a/packages/data/src/characters/geo/ningguang.gts
+++ b/packages/data/src/characters/geo/ningguang.gts
@@ -119,9 +119,8 @@ define card {
   since "v3.3.0";
   cost DiceType.Geo, 3;
   talent Ningguang {
-    on staged,
-      :{
-        :useSkill(JadeScreen);
-      };
+    on staged {
+      :useSkill(JadeScreen);
+    };
   };
 };

--- a/packages/data/src/characters/geo/noelle.gts
+++ b/packages/data/src/characters/geo/noelle.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 116022
@@ -133,9 +129,10 @@ define card {
   since "v3.3.0";
   cost DiceType.Geo, 3;
   talent Noelle {
-    on enter {
-      :useSkill(Breastplate);
-    };
+    on staged,
+      :{
+        :useSkill(Breastplate);
+      };
     on useSkill {
       when :(
         :e.isSkillType("normal") && :query($.my.combatStatus.def(FullPlate))

--- a/packages/data/src/characters/geo/noelle.gts
+++ b/packages/data/src/characters/geo/noelle.gts
@@ -129,10 +129,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Geo, 3;
   talent Noelle {
-    on staged,
-      :{
-        :useSkill(Breastplate);
-      };
+    on staged {
+      :useSkill(Breastplate);
+    };
     on useSkill {
       when :(
         :e.isSkillType("normal") && :query($.my.combatStatus.def(FullPlate))

--- a/packages/data/src/characters/geo/stonehide_lawachurl.gts
+++ b/packages/data/src/characters/geo/stonehide_lawachurl.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 126012
@@ -149,9 +145,10 @@ define card {
   cost DiceType.Geo, 4;
   cost DiceType.Energy, 2;
   talent StonehideLawachurl {
-    on enter {
-      :useSkill(UpaShato);
-    };
+    on staged,
+      :{
+        :useSkill(UpaShato);
+      };
     on defeated {
       when :( :e.source.id === :self.master.id );
       listenTo all;

--- a/packages/data/src/characters/geo/stonehide_lawachurl.gts
+++ b/packages/data/src/characters/geo/stonehide_lawachurl.gts
@@ -145,10 +145,9 @@ define card {
   cost DiceType.Geo, 4;
   cost DiceType.Energy, 2;
   talent StonehideLawachurl {
-    on staged,
-      :{
-        :useSkill(UpaShato);
-      };
+    on staged {
+      :useSkill(UpaShato);
+    };
     on defeated {
       when :( :e.source.id === :self.master.id );
       listenTo all;

--- a/packages/data/src/characters/geo/xilonen.gts
+++ b/packages/data/src/characters/geo/xilonen.gts
@@ -364,10 +364,9 @@ define card {
     return ch && !ch.hasNightsoulsBlessing();
   };
   talent Xilonen {
-    on staged,
-      :{
-        :useSkill(YohualsScratch);
-      };
+    on staged {
+      :useSkill(YohualsScratch);
+    };
     on switchActive {
       when :( :e.switchInfo.to.hasNightsoulsBlessing() );
       usage perRound, 2;

--- a/packages/data/src/characters/geo/xilonen.gts
+++ b/packages/data/src/characters/geo/xilonen.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 116111
@@ -368,9 +364,10 @@ define card {
     return ch && !ch.hasNightsoulsBlessing();
   };
   talent Xilonen {
-    on enter {
-      :useSkill(YohualsScratch);
-    };
+    on staged,
+      :{
+        :useSkill(YohualsScratch);
+      };
     on switchActive {
       when :( :e.switchInfo.to.hasNightsoulsBlessing() );
       usage perRound, 2;

--- a/packages/data/src/characters/geo/yun_jin.gts
+++ b/packages/data/src/characters/geo/yun_jin.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type CardHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type CardHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 116071
@@ -188,8 +183,9 @@ define card {
   cost DiceType.Geo, 3;
   cost DiceType.Energy, 2;
   talent YunJin {
-    on enter {
-      :useSkill(CliffbreakersBanner);
-    };
+    on staged,
+      :{
+        :useSkill(CliffbreakersBanner);
+      };
   };
 };

--- a/packages/data/src/characters/geo/yun_jin.gts
+++ b/packages/data/src/characters/geo/yun_jin.gts
@@ -183,9 +183,8 @@ define card {
   cost DiceType.Geo, 3;
   cost DiceType.Energy, 2;
   talent YunJin {
-    on staged,
-      :{
-        :useSkill(CliffbreakersBanner);
-      };
+    on staged {
+      :useSkill(CliffbreakersBanner);
+    };
   };
 };

--- a/packages/data/src/characters/geo/zhongli.gts
+++ b/packages/data/src/characters/geo/zhongli.gts
@@ -141,9 +141,10 @@ define card {
   since "v3.7.0";
   cost DiceType.Geo, 5;
   talent Zhongli {
-    on enter {
-      :useSkill(DominusLapidisStrikingStone);
-    };
+    on staged,
+      :{
+        :useSkill(DominusLapidisStrikingStone);
+      };
     on increaseDamage {
       when :{
         return (

--- a/packages/data/src/characters/geo/zhongli.gts
+++ b/packages/data/src/characters/geo/zhongli.gts
@@ -141,10 +141,9 @@ define card {
   since "v3.7.0";
   cost DiceType.Geo, 5;
   talent Zhongli {
-    on staged,
-      :{
-        :useSkill(DominusLapidisStrikingStone);
-      };
+    on staged {
+      :useSkill(DominusLapidisStrikingStone);
+    };
     on increaseDamage {
       when :{
         return (

--- a/packages/data/src/characters/hydro/abyss_herald_wicked_torrents.gts
+++ b/packages/data/src/characters/hydro/abyss_herald_wicked_torrents.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 122036
@@ -249,11 +245,12 @@ define card {
   since "v4.6.0";
   cost DiceType.Hydro, 1;
   talent AbyssHeraldWickedTorrents, none {
-    on enter {
-      :combatStatus(SurgingUndercurrentCombatStatus);
-      if (:self.master.getVariable("wateryRebirthTriggered")) {
-        :combatStatus(CurseOfTheUndercurrent, "opp");
-      }
-    };
+    on staged,
+      :{
+        :combatStatus(SurgingUndercurrentCombatStatus);
+        if (:self.master.getVariable("wateryRebirthTriggered")) {
+          :combatStatus(CurseOfTheUndercurrent, "opp");
+        }
+      };
   };
 };

--- a/packages/data/src/characters/hydro/abyss_herald_wicked_torrents.gts
+++ b/packages/data/src/characters/hydro/abyss_herald_wicked_torrents.gts
@@ -245,12 +245,11 @@ define card {
   since "v4.6.0";
   cost DiceType.Hydro, 1;
   talent AbyssHeraldWickedTorrents, none {
-    on staged,
-      :{
-        :combatStatus(SurgingUndercurrentCombatStatus);
-        if (:self.master.getVariable("wateryRebirthTriggered")) {
-          :combatStatus(CurseOfTheUndercurrent, "opp");
-        }
-      };
+    on staged {
+      :combatStatus(SurgingUndercurrentCombatStatus);
+      if (:self.master.getVariable("wateryRebirthTriggered")) {
+        :combatStatus(CurseOfTheUndercurrent, "opp");
+      }
+    };
   };
 };

--- a/packages/data/src/characters/hydro/aino.gts
+++ b/packages/data/src/characters/hydro/aino.gts
@@ -138,10 +138,9 @@ define card {
   cost DiceType.Hydro, 3;
   cost DiceType.Energy, 2;
   talent Aino {
-    on staged,
-      :{
-        :useSkill(PrecisionHydronicCooler);
-      };
+    on staged {
+      :useSkill(PrecisionHydronicCooler);
+    };
     on increaseDamage {
       when :(
         (

--- a/packages/data/src/characters/hydro/aino.gts
+++ b/packages/data/src/characters/hydro/aino.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  Reaction,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, Reaction } from "@gi-tcg/core/data";
 import { AgileSwitch, Empowerment } from "../../commons.gts";
 
 /**
@@ -143,9 +138,10 @@ define card {
   cost DiceType.Hydro, 3;
   cost DiceType.Energy, 2;
   talent Aino {
-    on enter {
-      :useSkill(PrecisionHydronicCooler);
-    };
+    on staged,
+      :{
+        :useSkill(PrecisionHydronicCooler);
+      };
     on increaseDamage {
       when :(
         (

--- a/packages/data/src/characters/hydro/alldevouring_narwhal.gts
+++ b/packages/data/src/characters/hydro/alldevouring_narwhal.gts
@@ -293,10 +293,9 @@ define card {
   since "v4.7.0";
   cost DiceType.Hydro, 4;
   talent AlldevouringNarwhal {
-    on staged,
-      :{
-        :useSkill(StarfallShower);
-      };
+    on staged {
+      :useSkill(StarfallShower);
+    };
     on StarfallShowerDisposeCard {
       usage perRound, 1;
       :heal(:get(:e.arg).diceCost(), :self.master);

--- a/packages/data/src/characters/hydro/alldevouring_narwhal.gts
+++ b/packages/data/src/characters/hydro/alldevouring_narwhal.gts
@@ -293,9 +293,10 @@ define card {
   since "v4.7.0";
   cost DiceType.Hydro, 4;
   talent AlldevouringNarwhal {
-    on enter {
-      :useSkill(StarfallShower);
-    };
+    on staged,
+      :{
+        :useSkill(StarfallShower);
+      };
     on StarfallShowerDisposeCard {
       usage perRound, 1;
       :heal(:get(:e.arg).diceCost(), :self.master);

--- a/packages/data/src/characters/hydro/barbara.gts
+++ b/packages/data/src/characters/hydro/barbara.gts
@@ -103,10 +103,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Hydro, 3;
   talent Barbara {
-    on staged,
-      :{
-        :useSkill(LetTheShowBegin);
-      };
+    on staged {
+      :useSkill(LetTheShowBegin);
+    };
     on deductOmniDiceSwitch {
       when :( :query($.my.summon.def(MelodyLoop)) );
       usage perRound, 1;

--- a/packages/data/src/characters/hydro/barbara.gts
+++ b/packages/data/src/characters/hydro/barbara.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SummonHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SummonHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 112011
@@ -108,9 +103,10 @@ define card {
   since "v3.3.0";
   cost DiceType.Hydro, 3;
   talent Barbara {
-    on enter {
-      :useSkill(LetTheShowBegin);
-    };
+    on staged,
+      :{
+        :useSkill(LetTheShowBegin);
+      };
     on deductOmniDiceSwitch {
       when :( :query($.my.summon.def(MelodyLoop)) );
       usage perRound, 1;

--- a/packages/data/src/characters/hydro/candace.gts
+++ b/packages/data/src/characters/hydro/candace.gts
@@ -208,9 +208,8 @@ define card {
   cost DiceType.Hydro, 3;
   cost DiceType.Energy, 2;
   talent Candace {
-    on staged,
-      :{
-        :useSkill(SacredRiteWagtailsTide);
-      };
+    on staged {
+      :useSkill(SacredRiteWagtailsTide);
+    };
   };
 };

--- a/packages/data/src/characters/hydro/candace.gts
+++ b/packages/data/src/characters/hydro/candace.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 12074
@@ -213,8 +208,9 @@ define card {
   cost DiceType.Hydro, 3;
   cost DiceType.Energy, 2;
   talent Candace {
-    on enter {
-      :useSkill(SacredRiteWagtailsTide);
-    };
+    on staged,
+      :{
+        :useSkill(SacredRiteWagtailsTide);
+      };
   };
 };

--- a/packages/data/src/characters/hydro/consecrated_horned_crocodile.gts
+++ b/packages/data/src/characters/hydro/consecrated_horned_crocodile.gts
@@ -118,10 +118,9 @@ define card {
   since "v6.3.0";
   cost DiceType.Hydro, 1;
   talent ConsecratedHornedCrocodile, none {
-    on staged,
-      :{
-        :createHandCard(BonecrunchersEnergyBlock);
-      };
+    on staged {
+      :createHandCard(BonecrunchersEnergyBlock);
+    };
     on playCard {
       when :( :e.card.definition.id === BonecrunchersEnergyBlock );
       :heal(1, $.macros.myMostInjured);

--- a/packages/data/src/characters/hydro/consecrated_horned_crocodile.gts
+++ b/packages/data/src/characters/hydro/consecrated_horned_crocodile.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import { BonecrunchersEnergyBlock } from "../../cards/event/other.gts";
 
 /**
@@ -122,9 +118,10 @@ define card {
   since "v6.3.0";
   cost DiceType.Hydro, 1;
   talent ConsecratedHornedCrocodile, none {
-    on enter {
-      :createHandCard(BonecrunchersEnergyBlock);
-    };
+    on staged,
+      :{
+        :createHandCard(BonecrunchersEnergyBlock);
+      };
     on playCard {
       when :( :e.card.definition.id === BonecrunchersEnergyBlock );
       :heal(1, $.macros.myMostInjured);

--- a/packages/data/src/characters/hydro/dahlia.gts
+++ b/packages/data/src/characters/hydro/dahlia.gts
@@ -132,10 +132,9 @@ define card {
   cost DiceType.Hydro, 3;
   cost DiceType.Energy, 2;
   talent Dahlia {
-    on staged,
-      :{
-        :useSkill(RadiantPsalter);
-      };
+    on staged {
+      :useSkill(RadiantPsalter);
+    };
     on beforeDefeated {
       when :( :query($.my.combatStatus.def(FavonianFavor)) );
       listenTo samePlayer;

--- a/packages/data/src/characters/hydro/dahlia.gts
+++ b/packages/data/src/characters/hydro/dahlia.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import { Shield } from "../../commons.gts";
 
 /**
@@ -136,9 +132,10 @@ define card {
   cost DiceType.Hydro, 3;
   cost DiceType.Energy, 2;
   talent Dahlia {
-    on enter {
-      :useSkill(RadiantPsalter);
-    };
+    on staged,
+      :{
+        :useSkill(RadiantPsalter);
+      };
     on beforeDefeated {
       when :( :query($.my.combatStatus.def(FavonianFavor)) );
       listenTo samePlayer;

--- a/packages/data/src/characters/hydro/furina.gts
+++ b/packages/data/src/characters/hydro/furina.gts
@@ -316,13 +316,14 @@ define card {
   since "v4.7.0";
   cost DiceType.Hydro, 3;
   talent [FurinaPneuma, FurinaOusia] {
-    on enter {
-      if (:self.master.definition.id === FurinaPneuma) {
-        :useSkill(SalonSolitairePneuma);
-      } else {
-        :useSkill(SalonSolitaireOusia);
-      }
-    };
+    on staged,
+      :{
+        if (:self.master.definition.id === FurinaPneuma) {
+          :useSkill(SalonSolitairePneuma);
+        } else {
+          :useSkill(SalonSolitaireOusia);
+        }
+      };
     on useSkill {
       when :( :e.isSkillType("elemental") );
       :characterStatus(CenterOfAttention, :self.master);

--- a/packages/data/src/characters/hydro/furina.gts
+++ b/packages/data/src/characters/hydro/furina.gts
@@ -316,14 +316,13 @@ define card {
   since "v4.7.0";
   cost DiceType.Hydro, 3;
   talent [FurinaPneuma, FurinaOusia] {
-    on staged,
-      :{
-        if (:self.master.definition.id === FurinaPneuma) {
-          :useSkill(SalonSolitairePneuma);
-        } else {
-          :useSkill(SalonSolitaireOusia);
-        }
-      };
+    on staged {
+      if (:self.master.definition.id === FurinaPneuma) {
+        :useSkill(SalonSolitairePneuma);
+      } else {
+        :useSkill(SalonSolitaireOusia);
+      }
+    };
     on useSkill {
       when :( :e.isSkillType("elemental") );
       :characterStatus(CenterOfAttention, :self.master);

--- a/packages/data/src/characters/hydro/hydro_hilichurl_rogue.gts
+++ b/packages/data/src/characters/hydro/hydro_hilichurl_rogue.gts
@@ -205,9 +205,10 @@ define card {
   since "v5.0.0";
   cost DiceType.Hydro, 3;
   talent HydroHilichurlRogue {
-    on enter {
-      :useSkill(SlashOfSurgingTides);
-    };
+    on staged,
+      :{
+        :useSkill(SlashOfSurgingTides);
+      };
     on deductOmniDiceSkill {
       when :( :e.isSkillType("technique") );
       usage perRound, 1;

--- a/packages/data/src/characters/hydro/hydro_hilichurl_rogue.gts
+++ b/packages/data/src/characters/hydro/hydro_hilichurl_rogue.gts
@@ -205,10 +205,9 @@ define card {
   since "v5.0.0";
   cost DiceType.Hydro, 3;
   talent HydroHilichurlRogue {
-    on staged,
-      :{
-        :useSkill(SlashOfSurgingTides);
-      };
+    on staged {
+      :useSkill(SlashOfSurgingTides);
+    };
     on deductOmniDiceSkill {
       when :( :e.isSkillType("technique") );
       usage perRound, 1;

--- a/packages/data/src/characters/hydro/hydro_tulpa.gts
+++ b/packages/data/src/characters/hydro/hydro_tulpa.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-  $,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType, $ } from "@gi-tcg/core/data";
 
 /**
  * @id 122061
@@ -307,9 +303,10 @@ define card {
   since "v6.1.0";
   cost DiceType.Hydro, 2;
   talent HydroTulpa, none {
-    on enter {
-      :characterStatus(ElementalLifeformHydro, :self.master);
-    };
+    on staged,
+      :{
+        :characterStatus(ElementalLifeformHydro, :self.master);
+      };
     on declareEnd {
       when :(
         :self.master.health >= 3 &&

--- a/packages/data/src/characters/hydro/hydro_tulpa.gts
+++ b/packages/data/src/characters/hydro/hydro_tulpa.gts
@@ -303,10 +303,9 @@ define card {
   since "v6.1.0";
   cost DiceType.Hydro, 2;
   talent HydroTulpa, none {
-    on staged,
-      :{
-        :characterStatus(ElementalLifeformHydro, :self.master);
-      };
+    on staged {
+      :characterStatus(ElementalLifeformHydro, :self.master);
+    };
     on declareEnd {
       when :(
         :self.master.health >= 3 &&

--- a/packages/data/src/characters/hydro/kamisato_ayato.gts
+++ b/packages/data/src/characters/hydro/kamisato_ayato.gts
@@ -153,10 +153,9 @@ define card {
   talent KamisatoAyato {
     variable deductEffectHasBeenTriggeredFromThisCard, 0;
     variable skillIsUsedWithKanka, 0;
-    on staged,
-      :{
-        :useSkill(KamisatoArtKyouka);
-      };
+    on staged {
+      :useSkill(KamisatoArtKyouka);
+    };
     on useSkill {
       when :( :e.isSkillType("normal") );
       if (

--- a/packages/data/src/characters/hydro/kamisato_ayato.gts
+++ b/packages/data/src/characters/hydro/kamisato_ayato.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type StatusHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type StatusHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 112062
@@ -158,9 +153,10 @@ define card {
   talent KamisatoAyato {
     variable deductEffectHasBeenTriggeredFromThisCard, 0;
     variable skillIsUsedWithKanka, 0;
-    on enter {
-      :useSkill(KamisatoArtKyouka);
-    };
+    on staged,
+      :{
+        :useSkill(KamisatoArtKyouka);
+      };
     on useSkill {
       when :( :e.isSkillType("normal") );
       if (

--- a/packages/data/src/characters/hydro/mirror_maiden.gts
+++ b/packages/data/src/characters/hydro/mirror_maiden.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 122022
@@ -142,8 +137,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Hydro, 3;
   talent MirrorMaiden {
-    on enter {
-      :useSkill(InfluxBlast);
-    };
+    on staged,
+      :{
+        :useSkill(InfluxBlast);
+      };
   };
 };

--- a/packages/data/src/characters/hydro/mirror_maiden.gts
+++ b/packages/data/src/characters/hydro/mirror_maiden.gts
@@ -137,9 +137,8 @@ define card {
   since "v3.3.0";
   cost DiceType.Hydro, 3;
   talent MirrorMaiden {
-    on staged,
-      :{
-        :useSkill(InfluxBlast);
-      };
+    on staged {
+      :useSkill(InfluxBlast);
+    };
   };
 };

--- a/packages/data/src/characters/hydro/mona.gts
+++ b/packages/data/src/characters/hydro/mona.gts
@@ -13,10 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 112031

--- a/packages/data/src/characters/hydro/mualani.gts
+++ b/packages/data/src/characters/hydro/mualani.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 112141

--- a/packages/data/src/characters/hydro/neuvillette.gts
+++ b/packages/data/src/characters/hydro/neuvillette.gts
@@ -188,10 +188,9 @@ define card {
   cost DiceType.Hydro, 1;
   cost DiceType.Void, 2;
   talent Neuvillette {
-    on staged,
-      :{
-        :useSkill(AsWaterSeeksEquilibrium);
-      };
+    on staged {
+      :useSkill(AsWaterSeeksEquilibrium);
+    };
     on useSkill {
       when :( :hasPhaseReaction("my", (e) => e.relatedTo(DamageType.Hydro)) );
       listenTo samePlayer;

--- a/packages/data/src/characters/hydro/neuvillette.gts
+++ b/packages/data/src/characters/hydro/neuvillette.gts
@@ -188,9 +188,10 @@ define card {
   cost DiceType.Hydro, 1;
   cost DiceType.Void, 2;
   talent Neuvillette {
-    on enter {
-      :useSkill(AsWaterSeeksEquilibrium);
-    };
+    on staged,
+      :{
+        :useSkill(AsWaterSeeksEquilibrium);
+      };
     on useSkill {
       when :( :hasPhaseReaction("my", (e) => e.relatedTo(DamageType.Hydro)) );
       listenTo samePlayer;

--- a/packages/data/src/characters/hydro/nilou.gts
+++ b/packages/data/src/characters/hydro/nilou.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  Reaction,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, Reaction } from "@gi-tcg/core/data";
 
 /**
  * @id 112082
@@ -166,8 +161,9 @@ define card {
   since "v4.2.0";
   cost DiceType.Hydro, 3;
   talent Nilou {
-    on enter {
-      :useSkill(DanceOfHaftkarsvar);
-    };
+    on staged,
+      :{
+        :useSkill(DanceOfHaftkarsvar);
+      };
   };
 };

--- a/packages/data/src/characters/hydro/nilou.gts
+++ b/packages/data/src/characters/hydro/nilou.gts
@@ -161,9 +161,8 @@ define card {
   since "v4.2.0";
   cost DiceType.Hydro, 3;
   talent Nilou {
-    on staged,
-      :{
-        :useSkill(DanceOfHaftkarsvar);
-      };
+    on staged {
+      :useSkill(DanceOfHaftkarsvar);
+    };
   };
 };

--- a/packages/data/src/characters/hydro/rhodeia_of_loch.gts
+++ b/packages/data/src/characters/hydro/rhodeia_of_loch.gts
@@ -243,9 +243,8 @@ define card {
   cost DiceType.Hydro, 4;
   cost DiceType.Energy, 3;
   talent RhodeiaOfLoch {
-    on staged,
-      :{
-        :useSkill(TideAndTorrent);
-      };
+    on staged {
+      :useSkill(TideAndTorrent);
+    };
   };
 };

--- a/packages/data/src/characters/hydro/rhodeia_of_loch.gts
+++ b/packages/data/src/characters/hydro/rhodeia_of_loch.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SummonHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SummonHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 122013
@@ -248,8 +243,9 @@ define card {
   cost DiceType.Hydro, 4;
   cost DiceType.Energy, 3;
   talent RhodeiaOfLoch {
-    on enter {
-      :useSkill(TideAndTorrent);
-    };
+    on staged,
+      :{
+        :useSkill(TideAndTorrent);
+      };
   };
 };

--- a/packages/data/src/characters/hydro/sangonomiya_kokomi.gts
+++ b/packages/data/src/characters/hydro/sangonomiya_kokomi.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SummonHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SummonHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 112051
@@ -151,8 +146,9 @@ define card {
   cost DiceType.Hydro, 3;
   cost DiceType.Energy, 2;
   talent SangonomiyaKokomi {
-    on enter {
-      :useSkill(NereidsAscension);
-    };
+    on staged,
+      :{
+        :useSkill(NereidsAscension);
+      };
   };
 };

--- a/packages/data/src/characters/hydro/sangonomiya_kokomi.gts
+++ b/packages/data/src/characters/hydro/sangonomiya_kokomi.gts
@@ -146,9 +146,8 @@ define card {
   cost DiceType.Hydro, 3;
   cost DiceType.Energy, 2;
   talent SangonomiyaKokomi {
-    on staged,
-      :{
-        :useSkill(NereidsAscension);
-      };
+    on staged {
+      :useSkill(NereidsAscension);
+    };
   };
 };

--- a/packages/data/src/characters/hydro/sigewinne.gts
+++ b/packages/data/src/characters/hydro/sigewinne.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import { SourcewaterDroplet } from "./neuvillette.gts";
 import { BondOfLife } from "../../commons.gts";
 
@@ -266,9 +262,10 @@ define card {
   since "v5.2.0";
   cost DiceType.Hydro, 3;
   talent Sigewinne {
-    on enter {
-      :useSkill(ReboundHydrotherapy);
-    };
+    on staged,
+      :{
+        :useSkill(ReboundHydrotherapy);
+      };
     on useSkill {
       when :( :e.skill.definition.id === ReboundHydrotherapy );
       :combatStatus(Convalescence);

--- a/packages/data/src/characters/hydro/sigewinne.gts
+++ b/packages/data/src/characters/hydro/sigewinne.gts
@@ -262,10 +262,9 @@ define card {
   since "v5.2.0";
   cost DiceType.Hydro, 3;
   talent Sigewinne {
-    on staged,
-      :{
-        :useSkill(ReboundHydrotherapy);
-      };
+    on staged {
+      :useSkill(ReboundHydrotherapy);
+    };
     on useSkill {
       when :( :e.skill.definition.id === ReboundHydrotherapy );
       :combatStatus(Convalescence);

--- a/packages/data/src/characters/hydro/tartaglia.gts
+++ b/packages/data/src/characters/hydro/tartaglia.gts
@@ -219,10 +219,9 @@ define card {
   since "v3.7.0";
   cost DiceType.Hydro, 3;
   talent Tartaglia {
-    on staged,
-      :{
-        :useSkill(FoulLegacyRagingTide);
-      };
+    on staged {
+      :useSkill(FoulLegacyRagingTide);
+    };
     on endPhase {
       when :( :query($.opp.active.has($.typeStatus.def(Riptide))) );
       :damage(DamageType.Piercing, 1, $.opp.active);

--- a/packages/data/src/characters/hydro/tartaglia.gts
+++ b/packages/data/src/characters/hydro/tartaglia.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type StatusHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type StatusHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 112042
@@ -224,9 +219,10 @@ define card {
   since "v3.7.0";
   cost DiceType.Hydro, 3;
   talent Tartaglia {
-    on enter {
-      :useSkill(FoulLegacyRagingTide);
-    };
+    on staged,
+      :{
+        :useSkill(FoulLegacyRagingTide);
+      };
     on endPhase {
       when :( :query($.opp.active.has($.typeStatus.def(Riptide))) );
       :damage(DamageType.Piercing, 1, $.opp.active);

--- a/packages/data/src/characters/hydro/xingqiu.gts
+++ b/packages/data/src/characters/hydro/xingqiu.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 112022
@@ -149,8 +144,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Hydro, 3;
   talent Xingqiu {
-    on enter {
-      :useSkill(FatalRainscreen);
-    };
+    on staged,
+      :{
+        :useSkill(FatalRainscreen);
+      };
   };
 };

--- a/packages/data/src/characters/hydro/xingqiu.gts
+++ b/packages/data/src/characters/hydro/xingqiu.gts
@@ -144,9 +144,8 @@ define card {
   since "v3.3.0";
   cost DiceType.Hydro, 3;
   talent Xingqiu {
-    on staged,
-      :{
-        :useSkill(FatalRainscreen);
-      };
+    on staged {
+      :useSkill(FatalRainscreen);
+    };
   };
 };

--- a/packages/data/src/characters/hydro/yelan.gts
+++ b/packages/data/src/characters/hydro/yelan.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 112091
@@ -150,9 +146,10 @@ define card {
   since "v4.3.0";
   cost DiceType.Hydro, 3;
   talent Yelan {
-    on enter {
-      :useSkill(LingeringLifeline);
-    };
+    on staged,
+      :{
+        :useSkill(LingeringLifeline);
+      };
     on roll {
       const elements = new Set(
         :queryAll($.my.character.includesDefeated).map((char) =>

--- a/packages/data/src/characters/hydro/yelan.gts
+++ b/packages/data/src/characters/hydro/yelan.gts
@@ -146,10 +146,9 @@ define card {
   since "v4.3.0";
   cost DiceType.Hydro, 3;
   talent Yelan {
-    on staged,
-      :{
-        :useSkill(LingeringLifeline);
-      };
+    on staged {
+      :useSkill(LingeringLifeline);
+    };
     on roll {
       const elements = new Set(
         :queryAll($.my.character.includesDefeated).map((char) =>

--- a/packages/data/src/characters/pyro/abyss_lector_fathomless_flames.gts
+++ b/packages/data/src/characters/pyro/abyss_lector_fathomless_flames.gts
@@ -208,12 +208,11 @@ define card {
   since "v3.7.0";
   cost DiceType.Pyro, 2;
   talent AbyssLectorFathomlessFlames, none {
-    on staged,
-      :{
-        if (:self.master.getVariable("fieryRebirthTriggered")) {
-          :characterStatus(AegisOfAbyssalFlame, :self.master);
-          :dispose();
-        }
-      };
+    on staged {
+      if (:self.master.getVariable("fieryRebirthTriggered")) {
+        :characterStatus(AegisOfAbyssalFlame, :self.master);
+        :dispose();
+      }
+    };
   };
 };

--- a/packages/data/src/characters/pyro/abyss_lector_fathomless_flames.gts
+++ b/packages/data/src/characters/pyro/abyss_lector_fathomless_flames.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 123021
@@ -212,10 +208,12 @@ define card {
   since "v3.7.0";
   cost DiceType.Pyro, 2;
   talent AbyssLectorFathomlessFlames, none {
-    on enter {
-      when :( :self.master.getVariable("fieryRebirthTriggered") );
-      :characterStatus(AegisOfAbyssalFlame, :self.master);
-      :dispose();
-    };
+    on staged,
+      :{
+        if (:self.master.getVariable("fieryRebirthTriggered")) {
+          :characterStatus(AegisOfAbyssalFlame, :self.master);
+          :dispose();
+        }
+      };
   };
 };

--- a/packages/data/src/characters/pyro/amber.gts
+++ b/packages/data/src/characters/pyro/amber.gts
@@ -124,9 +124,8 @@ define card {
   since "v3.7.0";
   cost DiceType.Pyro, 3;
   talent Amber {
-    on staged,
-      :{
-        :useSkill(ExplosivePuppet);
-      };
+    on staged {
+      :useSkill(ExplosivePuppet);
+    };
   };
 };

--- a/packages/data/src/characters/pyro/amber.gts
+++ b/packages/data/src/characters/pyro/amber.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SummonHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SummonHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 113041
@@ -129,8 +124,9 @@ define card {
   since "v3.7.0";
   cost DiceType.Pyro, 3;
   talent Amber {
-    on enter {
-      :useSkill(ExplosivePuppet);
-    };
+    on staged,
+      :{
+        :useSkill(ExplosivePuppet);
+      };
   };
 };

--- a/packages/data/src/characters/pyro/arlecchino.gts
+++ b/packages/data/src/characters/pyro/arlecchino.gts
@@ -187,12 +187,11 @@ define card {
   since "v5.4.0";
   cost DiceType.Pyro, 1;
   talent Arlecchino, action {
-    on staged,
-      :{
-        :characterStatus(BondOfLife, :self.master, {
-          overrideVariables: { usage: 3 },
-        });
-        // 消耗生命之契增伤的部分在被动技能 13147 里
-      };
+    on staged {
+      :characterStatus(BondOfLife, :self.master, {
+        overrideVariables: { usage: 3 },
+      });
+      // 消耗生命之契增伤的部分在被动技能 13147 里
+    };
   };
 };

--- a/packages/data/src/characters/pyro/arlecchino.gts
+++ b/packages/data/src/characters/pyro/arlecchino.gts
@@ -187,11 +187,12 @@ define card {
   since "v5.4.0";
   cost DiceType.Pyro, 1;
   talent Arlecchino, action {
-    on enter {
-      :characterStatus(BondOfLife, :self.master, {
-        overrideVariables: { usage: 3 },
-      });
-      // 消耗生命之契增伤的部分在被动技能 13147 里
-    };
+    on staged,
+      :{
+        :characterStatus(BondOfLife, :self.master, {
+          overrideVariables: { usage: 3 },
+        });
+        // 消耗生命之契增伤的部分在被动技能 13147 里
+      };
   };
 };

--- a/packages/data/src/characters/pyro/bennett.gts
+++ b/packages/data/src/characters/pyro/bennett.gts
@@ -137,8 +137,9 @@ define card {
   cost DiceType.Pyro, 4;
   cost DiceType.Energy, 2;
   talent Bennett {
-    on enter {
-      :useSkill(FantasticVoyage);
-    };
+    on staged,
+      :{
+        :useSkill(FantasticVoyage);
+      };
   };
 };

--- a/packages/data/src/characters/pyro/bennett.gts
+++ b/packages/data/src/characters/pyro/bennett.gts
@@ -137,9 +137,8 @@ define card {
   cost DiceType.Pyro, 4;
   cost DiceType.Energy, 2;
   talent Bennett {
-    on staged,
-      :{
-        :useSkill(FantasticVoyage);
-      };
+    on staged {
+      :useSkill(FantasticVoyage);
+    };
   };
 };

--- a/packages/data/src/characters/pyro/crimson_witch_of_embers.gts
+++ b/packages/data/src/characters/pyro/crimson_witch_of_embers.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 163011

--- a/packages/data/src/characters/pyro/dehya.gts
+++ b/packages/data/src/characters/pyro/dehya.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 113094
@@ -200,9 +195,10 @@ define card {
   since "v4.1.0";
   cost DiceType.Pyro, 4;
   talent Dehya {
-    on enter {
-      :useSkill(MoltenInferno);
-    };
+    on staged,
+      :{
+        :useSkill(MoltenInferno);
+      };
     on endPhase {
       when :( :self.master.health <= 6 );
       :heal(2, :self.master);

--- a/packages/data/src/characters/pyro/dehya.gts
+++ b/packages/data/src/characters/pyro/dehya.gts
@@ -195,10 +195,9 @@ define card {
   since "v4.1.0";
   cost DiceType.Pyro, 4;
   talent Dehya {
-    on staged,
-      :{
-        :useSkill(MoltenInferno);
-      };
+    on staged {
+      :useSkill(MoltenInferno);
+    };
     on endPhase {
       when :( :self.master.health <= 6 );
       :heal(2, :self.master);

--- a/packages/data/src/characters/pyro/diluc.gts
+++ b/packages/data/src/characters/pyro/diluc.gts
@@ -106,10 +106,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Pyro, 3;
   talent Diluc {
-    on staged,
-      :{
-        :useSkill(SearingOnslaught);
-      };
+    on staged {
+      :useSkill(SearingOnslaught);
+    };
     on deductElementDiceSkill {
       when :(
         :e.action.skill.definition.id === SearingOnslaught &&

--- a/packages/data/src/characters/pyro/diluc.gts
+++ b/packages/data/src/characters/pyro/diluc.gts
@@ -13,10 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 113011
@@ -109,9 +106,10 @@ define card {
   since "v3.3.0";
   cost DiceType.Pyro, 3;
   talent Diluc {
-    on enter {
-      :useSkill(SearingOnslaught);
-    };
+    on staged,
+      :{
+        :useSkill(SearingOnslaught);
+      };
     on deductElementDiceSkill {
       when :(
         :e.action.skill.definition.id === SearingOnslaught &&

--- a/packages/data/src/characters/pyro/emperor_of_fire_and_iron.gts
+++ b/packages/data/src/characters/pyro/emperor_of_fire_and_iron.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type CardHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type CardHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 23046
@@ -221,9 +216,10 @@ define card {
   since "v4.6.0";
   cost DiceType.Pyro, 1;
   talent EmperorOfFireAndIron, none {
-    on enter {
-      :apply(DamageType.Pyro, :self.master);
-    };
+    on staged,
+      :{
+        :apply(DamageType.Pyro, :self.master);
+      };
     on dispose {
       when :{
         return (

--- a/packages/data/src/characters/pyro/emperor_of_fire_and_iron.gts
+++ b/packages/data/src/characters/pyro/emperor_of_fire_and_iron.gts
@@ -216,10 +216,9 @@ define card {
   since "v4.6.0";
   cost DiceType.Pyro, 1;
   talent EmperorOfFireAndIron, none {
-    on staged,
-      :{
-        :apply(DamageType.Pyro, :self.master);
-      };
+    on staged {
+      :apply(DamageType.Pyro, :self.master);
+    };
     on dispose {
       when :{
         return (

--- a/packages/data/src/characters/pyro/eremite_scorching_loremaster.gts
+++ b/packages/data/src/characters/pyro/eremite_scorching_loremaster.gts
@@ -176,10 +176,9 @@ define card {
   since "v4.3.0";
   cost DiceType.Pyro, 3;
   talent EremiteScorchingLoremaster {
-    on staged,
-      :{
-        :useSkill(BlazingStrike);
-      };
+    on staged {
+      :useSkill(BlazingStrike);
+    };
     on defeated {
       when :( !:e.target.isMine() && :e.via.definition.id === 1230311 );
       listenTo all;

--- a/packages/data/src/characters/pyro/eremite_scorching_loremaster.gts
+++ b/packages/data/src/characters/pyro/eremite_scorching_loremaster.gts
@@ -176,9 +176,10 @@ define card {
   since "v4.3.0";
   cost DiceType.Pyro, 3;
   talent EremiteScorchingLoremaster {
-    on enter {
-      :useSkill(BlazingStrike);
-    };
+    on staged,
+      :{
+        :useSkill(BlazingStrike);
+      };
     on defeated {
       when :( !:e.target.isMine() && :e.via.definition.id === 1230311 );
       listenTo all;

--- a/packages/data/src/characters/pyro/fatui_pyro_agent.gts
+++ b/packages/data/src/characters/pyro/fatui_pyro_agent.gts
@@ -155,9 +155,8 @@ define card {
   since "v3.3.0";
   cost DiceType.Pyro, 3;
   talent FatuiPyroAgent {
-    on staged,
-      :{
-        :useSkill(Prowl);
-      };
+    on staged {
+      :useSkill(Prowl);
+    };
   };
 };

--- a/packages/data/src/characters/pyro/fatui_pyro_agent.gts
+++ b/packages/data/src/characters/pyro/fatui_pyro_agent.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 123012
@@ -159,8 +155,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Pyro, 3;
   talent FatuiPyroAgent {
-    on enter {
-      :useSkill(Prowl);
-    };
+    on staged,
+      :{
+        :useSkill(Prowl);
+      };
   };
 };

--- a/packages/data/src/characters/pyro/gaming.gts
+++ b/packages/data/src/characters/pyro/gaming.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 13164
@@ -174,9 +170,10 @@ define card {
   cost DiceType.Pyro, 3;
   cost DiceType.Energy, 3;
   talent Gaming {
-    on enter {
-      :useSkill(SuannisGildedDance);
-    };
+    on staged,
+      :{
+        :useSkill(SuannisGildedDance);
+      };
     on increaseSkillDamage {
       when :( :e.viaPlungingAttack() );
       :e.increaseDamage(1);

--- a/packages/data/src/characters/pyro/gaming.gts
+++ b/packages/data/src/characters/pyro/gaming.gts
@@ -170,10 +170,9 @@ define card {
   cost DiceType.Pyro, 3;
   cost DiceType.Energy, 3;
   talent Gaming {
-    on staged,
-      :{
-        :useSkill(SuannisGildedDance);
-      };
+    on staged {
+      :useSkill(SuannisGildedDance);
+    };
     on increaseSkillDamage {
       when :( :e.viaPlungingAttack() );
       :e.increaseDamage(1);

--- a/packages/data/src/characters/pyro/goldflame_qucusaur_tyrant.gts
+++ b/packages/data/src/characters/pyro/goldflame_qucusaur_tyrant.gts
@@ -155,9 +155,8 @@ define card {
   cost DiceType.Pyro, 3;
   cost DiceType.Energy, 2;
   talent GoldflameQucusaurTyrant {
-    on staged,
-      :{
-        :useSkill(GoldflameExplosion);
-      };
+    on staged {
+      :useSkill(GoldflameExplosion);
+    };
   };
 };

--- a/packages/data/src/characters/pyro/goldflame_qucusaur_tyrant.gts
+++ b/packages/data/src/characters/pyro/goldflame_qucusaur_tyrant.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 123061
@@ -159,8 +155,9 @@ define card {
   cost DiceType.Pyro, 3;
   cost DiceType.Energy, 2;
   talent GoldflameQucusaurTyrant {
-    on enter {
-      :useSkill(GoldflameExplosion);
-    };
+    on staged,
+      :{
+        :useSkill(GoldflameExplosion);
+      };
   };
 };

--- a/packages/data/src/characters/pyro/hu_tao.gts
+++ b/packages/data/src/characters/pyro/hu_tao.gts
@@ -130,10 +130,9 @@ define card {
   since "v3.7.0";
   cost DiceType.Pyro, 2;
   talent HuTao {
-    on staged,
-      :{
-        :useSkill(GuideToAfterlife);
-      };
+    on staged {
+      :useSkill(GuideToAfterlife);
+    };
     on increaseSkillDamage {
       when :( :self.master.health <= 6 && :e.type === DamageType.Pyro );
       :e.increaseDamage(1);

--- a/packages/data/src/characters/pyro/hu_tao.gts
+++ b/packages/data/src/characters/pyro/hu_tao.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 113072
@@ -134,9 +130,10 @@ define card {
   since "v3.7.0";
   cost DiceType.Pyro, 2;
   talent HuTao {
-    on enter {
-      :useSkill(GuideToAfterlife);
-    };
+    on staged,
+      :{
+        :useSkill(GuideToAfterlife);
+      };
     on increaseSkillDamage {
       when :( :self.master.health <= 6 && :e.type === DamageType.Pyro );
       :e.increaseDamage(1);

--- a/packages/data/src/characters/pyro/klee.gts
+++ b/packages/data/src/characters/pyro/klee.gts
@@ -148,9 +148,8 @@ define card {
   since "v3.4.0";
   cost DiceType.Pyro, 3;
   talent Klee {
-    on staged,
-      :{
-        :useSkill(JumpyDumpty);
-      };
+    on staged {
+      :useSkill(JumpyDumpty);
+    };
   };
 };

--- a/packages/data/src/characters/pyro/klee.gts
+++ b/packages/data/src/characters/pyro/klee.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 113062
@@ -153,8 +148,9 @@ define card {
   since "v3.4.0";
   cost DiceType.Pyro, 3;
   talent Klee {
-    on enter {
-      :useSkill(JumpyDumpty);
-    };
+    on staged,
+      :{
+        :useSkill(JumpyDumpty);
+      };
   };
 };

--- a/packages/data/src/characters/pyro/lord_of_eroded_primal_fire.gts
+++ b/packages/data/src/characters/pyro/lord_of_eroded_primal_fire.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 123051

--- a/packages/data/src/characters/pyro/lyney.gts
+++ b/packages/data/src/characters/pyro/lyney.gts
@@ -159,10 +159,9 @@ define card {
   since "v4.3.0";
   cost DiceType.Pyro, 3;
   talent Lyney {
-    on staged,
-      :{
-        :useSkill(PropArrow);
-      };
+    on staged {
+      :useSkill(PropArrow);
+    };
     on increaseSkillDamage {
       when :(
         [Lyney as number, GrinmalkinHat as number].includes(

--- a/packages/data/src/characters/pyro/lyney.gts
+++ b/packages/data/src/characters/pyro/lyney.gts
@@ -13,12 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  Aura,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, Aura, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 113101
@@ -164,9 +159,10 @@ define card {
   since "v4.3.0";
   cost DiceType.Pyro, 3;
   talent Lyney {
-    on enter {
-      :useSkill(PropArrow);
-    };
+    on staged,
+      :{
+        :useSkill(PropArrow);
+      };
     on increaseSkillDamage {
       when :(
         [Lyney as number, GrinmalkinHat as number].includes(

--- a/packages/data/src/characters/pyro/mavuika.gts
+++ b/packages/data/src/characters/pyro/mavuika.gts
@@ -150,13 +150,14 @@ define card {
   cost DiceType.Void, 2;
   technique {
     target $.my.character.def(Mavuika);
-    on enter {
-      const summons = :queryAll($.my.summon);
-      if (summons.length > 0) {
-        const summon = :random(summons);
-        :triggerEndPhaseSkill(summon);
-      }
-    };
+    on staged,
+      :{
+        const summons = :queryAll($.my.summon);
+        if (summons.length > 0) {
+          const summon = :random(summons);
+          :triggerEndPhaseSkill(summon);
+        }
+      };
     skill {
       id 1131551 as BlazingTrail;
       usage 2;
@@ -343,13 +344,14 @@ define card {
   since "v5.7.0";
   cost DiceType.Pyro, 1;
   talent Mavuika, none {
-    on enter {
-      :selectAndCreateHandCard([
-        FlamestriderBlazingTrail,
-        FlamestriderFullThrottle,
-        FlamestriderSoaringAscent,
-      ]);
-    };
+    on staged,
+      :{
+        :selectAndCreateHandCard([
+          FlamestriderBlazingTrail,
+          FlamestriderFullThrottle,
+          FlamestriderSoaringAscent,
+        ]);
+      };
     on playCard {
       when :(
         :e.hasCardTag("technique") && :self.master.hasStatus(NightsoulsBlessing)

--- a/packages/data/src/characters/pyro/mavuika.gts
+++ b/packages/data/src/characters/pyro/mavuika.gts
@@ -150,14 +150,13 @@ define card {
   cost DiceType.Void, 2;
   technique {
     target $.my.character.def(Mavuika);
-    on staged,
-      :{
-        const summons = :queryAll($.my.summon);
-        if (summons.length > 0) {
-          const summon = :random(summons);
-          :triggerEndPhaseSkill(summon);
-        }
-      };
+    on staged {
+      const summons = :queryAll($.my.summon);
+      if (summons.length > 0) {
+        const summon = :random(summons);
+        :triggerEndPhaseSkill(summon);
+      }
+    };
     skill {
       id 1131551 as BlazingTrail;
       usage 2;
@@ -344,14 +343,13 @@ define card {
   since "v5.7.0";
   cost DiceType.Pyro, 1;
   talent Mavuika, none {
-    on staged,
-      :{
-        :selectAndCreateHandCard([
-          FlamestriderBlazingTrail,
-          FlamestriderFullThrottle,
-          FlamestriderSoaringAscent,
-        ]);
-      };
+    on staged {
+      :selectAndCreateHandCard([
+        FlamestriderBlazingTrail,
+        FlamestriderFullThrottle,
+        FlamestriderSoaringAscent,
+      ]);
+    };
     on playCard {
       when :(
         :e.hasCardTag("technique") && :self.master.hasStatus(NightsoulsBlessing)

--- a/packages/data/src/characters/pyro/thoma.gts
+++ b/packages/data/src/characters/pyro/thoma.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 113111
@@ -144,8 +140,9 @@ define card {
   cost DiceType.Pyro, 3;
   cost DiceType.Energy, 2;
   talent Thoma {
-    on enter {
-      :useSkill(CrimsonOoyoroi);
-    };
+    on staged,
+      :{
+        :useSkill(CrimsonOoyoroi);
+      };
   };
 };

--- a/packages/data/src/characters/pyro/thoma.gts
+++ b/packages/data/src/characters/pyro/thoma.gts
@@ -140,9 +140,8 @@ define card {
   cost DiceType.Pyro, 3;
   cost DiceType.Energy, 2;
   talent Thoma {
-    on staged,
-      :{
-        :useSkill(CrimsonOoyoroi);
-      };
+    on staged {
+      :useSkill(CrimsonOoyoroi);
+    };
   };
 };

--- a/packages/data/src/characters/pyro/xiangling.gts
+++ b/packages/data/src/characters/pyro/xiangling.gts
@@ -121,9 +121,8 @@ define card {
   since "v3.3.0";
   cost DiceType.Pyro, 3;
   talent Xiangling {
-    on staged,
-      :{
-        :useSkill(GuobaAttack);
-      };
+    on staged {
+      :useSkill(GuobaAttack);
+    };
   };
 };

--- a/packages/data/src/characters/pyro/xiangling.gts
+++ b/packages/data/src/characters/pyro/xiangling.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 113021
@@ -125,8 +121,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Pyro, 3;
   talent Xiangling {
-    on enter {
-      :useSkill(GuobaAttack);
-    };
+    on staged,
+      :{
+        :useSkill(GuobaAttack);
+      };
   };
 };

--- a/packages/data/src/characters/pyro/xinyan.gts
+++ b/packages/data/src/characters/pyro/xinyan.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 113123
@@ -124,9 +120,10 @@ define card {
   cost DiceType.Pyro, 1;
   cost DiceType.Void, 2;
   talent Xinyan {
-    on enter {
-      :useSkill(DanceOnFire);
-    };
+    on staged,
+      :{
+        :useSkill(DanceOnFire);
+      };
     on increaseSkillDamage {
       when :( :player.hands.length <= 1 );
       usage perRound, 1;

--- a/packages/data/src/characters/pyro/xinyan.gts
+++ b/packages/data/src/characters/pyro/xinyan.gts
@@ -120,10 +120,9 @@ define card {
   cost DiceType.Pyro, 1;
   cost DiceType.Void, 2;
   talent Xinyan {
-    on staged,
-      :{
-        :useSkill(DanceOnFire);
-      };
+    on staged {
+      :useSkill(DanceOnFire);
+    };
     on increaseSkillDamage {
       when :( :player.hands.length <= 1 );
       usage perRound, 1;

--- a/packages/data/src/characters/pyro/yanfei.gts
+++ b/packages/data/src/characters/pyro/yanfei.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 113081
@@ -133,9 +129,10 @@ define card {
   cost DiceType.Void, 2;
   talent Yanfei {
     variable triggerSeal, 0;
-    on enter {
-      :useSkill(SealOfApproval);
-    };
+    on staged,
+      :{
+        :useSkill(SealOfApproval);
+      };
     on increaseSkillDamage {
       when :( :e.viaChargedAttack() && :e.target.health <= 6 );
       :e.increaseDamage(1);

--- a/packages/data/src/characters/pyro/yanfei.gts
+++ b/packages/data/src/characters/pyro/yanfei.gts
@@ -129,10 +129,9 @@ define card {
   cost DiceType.Void, 2;
   talent Yanfei {
     variable triggerSeal, 0;
-    on staged,
-      :{
-        :useSkill(SealOfApproval);
-      };
+    on staged {
+      :useSkill(SealOfApproval);
+    };
     on increaseSkillDamage {
       when :( :e.viaChargedAttack() && :e.target.health <= 6 );
       :e.increaseDamage(1);

--- a/packages/data/src/characters/pyro/yoimiya.gts
+++ b/packages/data/src/characters/pyro/yoimiya.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 
 /**
  * @id 113053
@@ -158,8 +154,9 @@ define card {
   since "v3.3.0";
   cost DiceType.Pyro, 1;
   talent Yoimiya {
-    on enter {
-      :useSkill(NiwabiFiredance);
-    };
+    on staged,
+      :{
+        :useSkill(NiwabiFiredance);
+      };
   };
 };

--- a/packages/data/src/characters/pyro/yoimiya.gts
+++ b/packages/data/src/characters/pyro/yoimiya.gts
@@ -154,9 +154,8 @@ define card {
   since "v3.3.0";
   cost DiceType.Pyro, 1;
   talent Yoimiya {
-    on staged,
-      :{
-        :useSkill(NiwabiFiredance);
-      };
+    on staged {
+      :useSkill(NiwabiFiredance);
+    };
   };
 };

--- a/packages/data/src/commons.gts
+++ b/packages/data/src/commons.gts
@@ -301,14 +301,13 @@ define summon {
     usage 1 { append; };
     :damage(DamageType.Electro, 2);
   };
-  defineSnippet giveOppRandomCardConductive,
-    :{
-      if (:oppPlayer.hands.length === 0) {
-        return;
-      }
-      const targetHand = :random(:oppPlayer.hands);
-      :attach(Conductive, targetHand);
-    };
+  defineSnippet giveOppRandomCardConductive {
+    if (:oppPlayer.hands.length === 0) {
+      return;
+    }
+    const targetHand = :random(:oppPlayer.hands);
+    :attach(Conductive, targetHand);
+  };
   on enter {
     :callSnippet.giveOppRandomCardConductive();
   };

--- a/packages/data/src/commons.gts
+++ b/packages/data/src/commons.gts
@@ -13,11 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import {
-  DamageType,
-  DiceType,
-  $,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType, $ } from "@gi-tcg/core/data";
 
 /**
  * @id 100

--- a/packages/data/src/old_versions/v3.3.0.gts
+++ b/packages/data/src/old_versions/v3.3.0.gts
@@ -1,9 +1,4 @@
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 import {
   AurousBlaze,
   FireworkFlareup,
@@ -134,8 +129,9 @@ define card {
   until "v3.3.0";
   cost DiceType.Dendro, 3;
   talent Collei {
-    on enter {
-      :useSkill(FloralBrush);
-    };
+    on staged,
+      :{
+        :useSkill(FloralBrush);
+      };
   };
 };

--- a/packages/data/src/old_versions/v3.3.0.gts
+++ b/packages/data/src/old_versions/v3.3.0.gts
@@ -129,9 +129,8 @@ define card {
   until "v3.3.0";
   cost DiceType.Dendro, 3;
   talent Collei {
-    on staged,
-      :{
-        :useSkill(FloralBrush);
-      };
+    on staged {
+      :useSkill(FloralBrush);
+    };
   };
 };

--- a/packages/data/src/old_versions/v3.5.0.gts
+++ b/packages/data/src/old_versions/v3.5.0.gts
@@ -1,8 +1,4 @@
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import {
   BakeKurage,
   TamakushiCasket,

--- a/packages/data/src/old_versions/v3.6.0.gts
+++ b/packages/data/src/old_versions/v3.6.0.gts
@@ -166,17 +166,18 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on enter {
-      void 0;
-      // 此版本只计算未击倒角色
-      const liyueCount = :queryAll($.my.character.tag("liyue")).length;
-      if (liyueCount > 0) {
-        :characterStatus(LithicGuard, :self.master, {
-          overrideVariables: {
-            shield: Math.min(liyueCount, 3),
-          },
-        });
-      }
-    };
+    on staged,
+      :{
+        void 0;
+        // 此版本只计算未击倒角色
+        const liyueCount = :queryAll($.my.character.tag("liyue")).length;
+        if (liyueCount > 0) {
+          :characterStatus(LithicGuard, :self.master, {
+            overrideVariables: {
+              shield: Math.min(liyueCount, 3),
+            },
+          });
+        }
+      };
   };
 };

--- a/packages/data/src/old_versions/v3.6.0.gts
+++ b/packages/data/src/old_versions/v3.6.0.gts
@@ -166,18 +166,17 @@ define card {
     on increaseSkillDamage {
       :e.increaseDamage(1);
     };
-    on staged,
-      :{
-        void 0;
-        // 此版本只计算未击倒角色
-        const liyueCount = :queryAll($.my.character.tag("liyue")).length;
-        if (liyueCount > 0) {
-          :characterStatus(LithicGuard, :self.master, {
-            overrideVariables: {
-              shield: Math.min(liyueCount, 3),
-            },
-          });
-        }
-      };
+    on staged {
+      void 0;
+      // 此版本只计算未击倒角色
+      const liyueCount = :queryAll($.my.character.tag("liyue")).length;
+      if (liyueCount > 0) {
+        :characterStatus(LithicGuard, :self.master, {
+          overrideVariables: {
+            shield: Math.min(liyueCount, 3),
+          },
+        });
+      }
+    };
   };
 };

--- a/packages/data/src/old_versions/v3.7.0.gts
+++ b/packages/data/src/old_versions/v3.7.0.gts
@@ -1,8 +1,4 @@
-import {
-  DamageType,
-  DiceType,
-  type SkillHandle,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType, type SkillHandle } from "@gi-tcg/core/data";
 import { AurousBlaze } from "../characters/pyro/yoimiya.gts";
 import { ThunderbeastsTarge } from "../characters/electro/beidou.gts";
 import { PyronadoStatus } from "../characters/pyro/xiangling.gts";

--- a/packages/data/src/old_versions/v3.8.0.gts
+++ b/packages/data/src/old_versions/v3.8.0.gts
@@ -1,4 +1,4 @@
-import { $, DamageType, DiceType} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import { VermillionHereafterEffect } from "../cards/equipment/artifacts.gts";
 
 /**

--- a/packages/data/src/old_versions/v4.0.0.gts
+++ b/packages/data/src/old_versions/v4.0.0.gts
@@ -89,10 +89,9 @@ define card {
   until "v4.0.0";
   cost DiceType.Hydro, 4;
   talent Tartaglia {
-    on staged,
-      :{
-        :useSkill(FoulLegacyRagingTide);
-      };
+    on staged {
+      :useSkill(FoulLegacyRagingTide);
+    };
     on endPhase {
       when :( :query($.opp.character.has($.typeStatus.def(Riptide))) );
       :damage(
@@ -206,10 +205,9 @@ define card {
   until "v4.0.0";
   cost DiceType.Cryo, 4;
   talent Diona {
-    on staged,
-      :{
-        :useSkill(IcyPaws);
-      };
+    on staged {
+      :useSkill(IcyPaws);
+    };
   };
 };
 
@@ -242,10 +240,9 @@ define card {
   until "v4.0.0";
   cost DiceType.Void, 2;
   support item {
-    on staged,
-      :{
-        :drawCards(1, { withTag: "food" });
-      };
+    on staged {
+      :drawCards(1, { withTag: "food" });
+    };
     on playCard {
       when :( :e.hasCardTag("food") );
       usage perRound, 1;

--- a/packages/data/src/old_versions/v4.0.0.gts
+++ b/packages/data/src/old_versions/v4.0.0.gts
@@ -89,9 +89,10 @@ define card {
   until "v4.0.0";
   cost DiceType.Hydro, 4;
   talent Tartaglia {
-    on enter {
-      :useSkill(FoulLegacyRagingTide);
-    };
+    on staged,
+      :{
+        :useSkill(FoulLegacyRagingTide);
+      };
     on endPhase {
       when :( :query($.opp.character.has($.typeStatus.def(Riptide))) );
       :damage(
@@ -205,9 +206,10 @@ define card {
   until "v4.0.0";
   cost DiceType.Cryo, 4;
   talent Diona {
-    on enter {
-      :useSkill(IcyPaws);
-    };
+    on staged,
+      :{
+        :useSkill(IcyPaws);
+      };
   };
 };
 
@@ -240,9 +242,10 @@ define card {
   until "v4.0.0";
   cost DiceType.Void, 2;
   support item {
-    on enter {
-      :drawCards(1, { withTag: "food" });
-    };
+    on staged,
+      :{
+        :drawCards(1, { withTag: "food" });
+      };
     on playCard {
       when :( :e.hasCardTag("food") );
       usage perRound, 1;

--- a/packages/data/src/old_versions/v4.1.0.gts
+++ b/packages/data/src/old_versions/v4.1.0.gts
@@ -97,10 +97,9 @@ define card {
   until "v4.1.0";
   cost DiceType.Hydro, 4;
   talent Xingqiu {
-    on staged,
-      :{
-        :useSkill(FatalRainscreen);
-      };
+    on staged {
+      :useSkill(FatalRainscreen);
+    };
   };
 };
 
@@ -138,10 +137,9 @@ define card {
   until "v4.1.0";
   cost DiceType.Hydro, 4;
   talent MirrorMaiden {
-    on staged,
-      :{
-        :useSkill(InfluxBlast);
-      };
+    on staged {
+      :useSkill(InfluxBlast);
+    };
   };
 };
 
@@ -159,10 +157,9 @@ define card {
   until "v4.1.0";
   cost DiceType.Hydro, 4;
   talent Barbara {
-    on staged,
-      :{
-        :useSkill(LetTheShowBegin);
-      };
+    on staged {
+      :useSkill(LetTheShowBegin);
+    };
   };
 };
 
@@ -197,10 +194,9 @@ define card {
   until "v4.1.0";
   cost DiceType.Cryo, 4;
   talent Chongyun {
-    on staged,
-      :{
-        :useSkill(ChonghuasLayeredFrost);
-      };
+    on staged {
+      :useSkill(ChonghuasLayeredFrost);
+    };
   };
 };
 
@@ -256,10 +252,9 @@ define card {
   until "v4.1.0";
   cost DiceType.Pyro, 4;
   talent Xiangling {
-    on staged,
-      :{
-        :useSkill(GuobaAttack);
-      };
+    on staged {
+      :useSkill(GuobaAttack);
+    };
   };
 };
 
@@ -292,10 +287,9 @@ define card {
   until "v4.1.0";
   cost DiceType.Pyro, 2;
   talent Yoimiya {
-    on staged,
-      :{
-        :useSkill(NiwabiFiredance);
-      };
+    on staged {
+      :useSkill(NiwabiFiredance);
+    };
     on useSkill {
       when :(
         :e.isSkillType("normal") && :self.master.hasStatus(NiwabiEnshou)
@@ -320,10 +314,9 @@ define card {
   cost DiceType.Hydro, 4;
   cost DiceType.Energy, 2;
   talent Candace {
-    on staged,
-      :{
-        :useSkill(SacredRiteWagtailsTide);
-      };
+    on staged {
+      :useSkill(SacredRiteWagtailsTide);
+    };
   };
 };
 
@@ -341,10 +334,9 @@ define card {
   until "v4.1.0";
   cost DiceType.Electro, 4;
   talent Razor {
-    on staged,
-      :{
-        :useSkill(ClawAndThunder);
-      };
+    on staged {
+      :useSkill(ClawAndThunder);
+    };
     on useSkill {
       when :( :e.skill.definition.id === ClawAndThunder );
       :gainEnergy(
@@ -372,10 +364,9 @@ define card {
   until "v4.1.0";
   cost DiceType.Electro, 3;
   talent Beidou {
-    on staged,
-      :{
-        :useSkill(Tidecaller);
-      };
+    on staged {
+      :useSkill(Tidecaller);
+    };
     on useSkill {
       when :{
         if (:e.skill.definition.id !== Wavestrider) {
@@ -412,10 +403,9 @@ define card {
   cost DiceType.Electro, 4;
   cost DiceType.Energy, 3;
   talent KujouSara {
-    on staged,
-      :{
-        :useSkill(SubjugationKoukouSendou);
-      };
+    on staged {
+      :useSkill(SubjugationKoukouSendou);
+    };
   };
 };
 
@@ -433,10 +423,9 @@ define card {
   until "v4.1.0";
   cost DiceType.Electro, 3;
   talent Cyno {
-    on staged,
-      :{
-        :useSkill(SecretRiteChasmicSoulfarer);
-      };
+    on staged {
+      :useSkill(SecretRiteChasmicSoulfarer);
+    };
     on increaseSkillDamage {
       when :{
         const status = :self.master.hasStatus(PactswornPathclearer)!;
@@ -499,10 +488,9 @@ define card {
   until "v4.1.0";
   cost DiceType.Pyro, 3;
   talent Amber {
-    on staged,
-      :{
-        :useSkill(ExplosivePuppet);
-      };
+    on staged {
+      :useSkill(ExplosivePuppet);
+    };
     on useSkill {
       when :( :e.isSkillType("normal") );
       const bunny = :query($.my.summon.def(BaronBunny));
@@ -585,10 +573,9 @@ define card {
   cost DiceType.Anemo, 4;
   cost DiceType.Energy, 3;
   talent Jean {
-    on staged,
-      :{
-        :useSkill(DandelionBreeze);
-      };
+    on staged {
+      :useSkill(DandelionBreeze);
+    };
   };
 };
 
@@ -625,10 +612,9 @@ define card {
   cost DiceType.Void, 2;
   talent Yanfei {
     variable triggerSeal, 0;
-    on staged,
-      :{
-        :useSkill(SealOfApproval);
-      };
+    on staged {
+      :useSkill(SealOfApproval);
+    };
     on increaseSkillDamage {
       when :( :e.viaChargedAttack() && :e.target.health <= 6 );
       :e.increaseDamage(1);

--- a/packages/data/src/old_versions/v4.1.0.gts
+++ b/packages/data/src/old_versions/v4.1.0.gts
@@ -97,9 +97,10 @@ define card {
   until "v4.1.0";
   cost DiceType.Hydro, 4;
   talent Xingqiu {
-    on enter {
-      :useSkill(FatalRainscreen);
-    };
+    on staged,
+      :{
+        :useSkill(FatalRainscreen);
+      };
   };
 };
 
@@ -137,9 +138,10 @@ define card {
   until "v4.1.0";
   cost DiceType.Hydro, 4;
   talent MirrorMaiden {
-    on enter {
-      :useSkill(InfluxBlast);
-    };
+    on staged,
+      :{
+        :useSkill(InfluxBlast);
+      };
   };
 };
 
@@ -157,9 +159,10 @@ define card {
   until "v4.1.0";
   cost DiceType.Hydro, 4;
   talent Barbara {
-    on enter {
-      :useSkill(LetTheShowBegin);
-    };
+    on staged,
+      :{
+        :useSkill(LetTheShowBegin);
+      };
   };
 };
 
@@ -194,9 +197,10 @@ define card {
   until "v4.1.0";
   cost DiceType.Cryo, 4;
   talent Chongyun {
-    on enter {
-      :useSkill(ChonghuasLayeredFrost);
-    };
+    on staged,
+      :{
+        :useSkill(ChonghuasLayeredFrost);
+      };
   };
 };
 
@@ -252,9 +256,10 @@ define card {
   until "v4.1.0";
   cost DiceType.Pyro, 4;
   talent Xiangling {
-    on enter {
-      :useSkill(GuobaAttack);
-    };
+    on staged,
+      :{
+        :useSkill(GuobaAttack);
+      };
   };
 };
 
@@ -287,9 +292,10 @@ define card {
   until "v4.1.0";
   cost DiceType.Pyro, 2;
   talent Yoimiya {
-    on enter {
-      :useSkill(NiwabiFiredance);
-    };
+    on staged,
+      :{
+        :useSkill(NiwabiFiredance);
+      };
     on useSkill {
       when :(
         :e.isSkillType("normal") && :self.master.hasStatus(NiwabiEnshou)
@@ -314,9 +320,10 @@ define card {
   cost DiceType.Hydro, 4;
   cost DiceType.Energy, 2;
   talent Candace {
-    on enter {
-      :useSkill(SacredRiteWagtailsTide);
-    };
+    on staged,
+      :{
+        :useSkill(SacredRiteWagtailsTide);
+      };
   };
 };
 
@@ -334,9 +341,10 @@ define card {
   until "v4.1.0";
   cost DiceType.Electro, 4;
   talent Razor {
-    on enter {
-      :useSkill(ClawAndThunder);
-    };
+    on staged,
+      :{
+        :useSkill(ClawAndThunder);
+      };
     on useSkill {
       when :( :e.skill.definition.id === ClawAndThunder );
       :gainEnergy(
@@ -364,9 +372,10 @@ define card {
   until "v4.1.0";
   cost DiceType.Electro, 3;
   talent Beidou {
-    on enter {
-      :useSkill(Tidecaller);
-    };
+    on staged,
+      :{
+        :useSkill(Tidecaller);
+      };
     on useSkill {
       when :{
         if (:e.skill.definition.id !== Wavestrider) {
@@ -403,9 +412,10 @@ define card {
   cost DiceType.Electro, 4;
   cost DiceType.Energy, 3;
   talent KujouSara {
-    on enter {
-      :useSkill(SubjugationKoukouSendou);
-    };
+    on staged,
+      :{
+        :useSkill(SubjugationKoukouSendou);
+      };
   };
 };
 
@@ -423,9 +433,10 @@ define card {
   until "v4.1.0";
   cost DiceType.Electro, 3;
   talent Cyno {
-    on enter {
-      :useSkill(SecretRiteChasmicSoulfarer);
-    };
+    on staged,
+      :{
+        :useSkill(SecretRiteChasmicSoulfarer);
+      };
     on increaseSkillDamage {
       when :{
         const status = :self.master.hasStatus(PactswornPathclearer)!;
@@ -488,9 +499,10 @@ define card {
   until "v4.1.0";
   cost DiceType.Pyro, 3;
   talent Amber {
-    on enter {
-      :useSkill(ExplosivePuppet);
-    };
+    on staged,
+      :{
+        :useSkill(ExplosivePuppet);
+      };
     on useSkill {
       when :( :e.isSkillType("normal") );
       const bunny = :query($.my.summon.def(BaronBunny));
@@ -573,9 +585,10 @@ define card {
   cost DiceType.Anemo, 4;
   cost DiceType.Energy, 3;
   talent Jean {
-    on enter {
-      :useSkill(DandelionBreeze);
-    };
+    on staged,
+      :{
+        :useSkill(DandelionBreeze);
+      };
   };
 };
 
@@ -612,9 +625,10 @@ define card {
   cost DiceType.Void, 2;
   talent Yanfei {
     variable triggerSeal, 0;
-    on enter {
-      :useSkill(SealOfApproval);
-    };
+    on staged,
+      :{
+        :useSkill(SealOfApproval);
+      };
     on increaseSkillDamage {
       when :( :e.viaChargedAttack() && :e.target.health <= 6 );
       :e.increaseDamage(1);

--- a/packages/data/src/old_versions/v4.2.0.gts
+++ b/packages/data/src/old_versions/v4.2.0.gts
@@ -1,9 +1,4 @@
-import {
-  $,
-  DamageType,
-  DiceType,
-  type SummonHandle,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, type SummonHandle } from "@gi-tcg/core/data";
 import {
   NORMAL_MIMICS,
   PREVIEW_MIMICS,
@@ -200,9 +195,10 @@ define card {
       visible false;
     };
     variable bubble, 0;
-    on enter {
-      :heal(3, :self.master);
-    };
+    on staged,
+      :{
+        :heal(3, :self.master);
+      };
     on healed {
       listenTo samePlayer;
       :addVariable("healedPts", :e.value);

--- a/packages/data/src/old_versions/v4.2.0.gts
+++ b/packages/data/src/old_versions/v4.2.0.gts
@@ -195,10 +195,9 @@ define card {
       visible false;
     };
     variable bubble, 0;
-    on staged,
-      :{
-        :heal(3, :self.master);
-      };
+    on staged {
+      :heal(3, :self.master);
+    };
     on healed {
       listenTo samePlayer;
       :addVariable("healedPts", :e.value);

--- a/packages/data/src/old_versions/v4.3.0.gts
+++ b/packages/data/src/old_versions/v4.3.0.gts
@@ -1,4 +1,4 @@
-import { $, DiceType} from "@gi-tcg/core/data";
+import { $, DiceType } from "@gi-tcg/core/data";
 import {
   StrifefulLightning,
   ThunderManifestation,

--- a/packages/data/src/old_versions/v4.4.0.gts
+++ b/packages/data/src/old_versions/v4.4.0.gts
@@ -13,16 +13,15 @@ define card {
   until "v4.4.0";
   cost DiceType.Void, 3;
   artifact {
-    on staged,
-      :{
-        :generateDice(:self.master.element(), 1);
-        const elementKinds = new Set(
-          :queryAll($.my.character.includesDefeated).map((ch) => ch.element()),
-        );
-        if (elementKinds.size >= 3) {
-          :generateDice(DiceType.Omni, 1);
-        }
-      };
+    on staged {
+      :generateDice(:self.master.element(), 1);
+      const elementKinds = new Set(
+        :queryAll($.my.character.includesDefeated).map((ch) => ch.element()),
+      );
+      if (elementKinds.size >= 3) {
+        :generateDice(DiceType.Omni, 1);
+      }
+    };
     on damaged {
       when :(
         !:e.target.isMine() && :self.master.isActive() && :e.getReaction()
@@ -62,10 +61,9 @@ define card {
   until "v4.4.0";
   cost DiceType.Aligned, 1;
   support place {
-    on staged,
-      :{
-        :rerollDice(1);
-      };
+    on staged {
+      :rerollDice(1);
+    };
     on roll {
       :e.addRerollCount(1);
     };

--- a/packages/data/src/old_versions/v4.4.0.gts
+++ b/packages/data/src/old_versions/v4.4.0.gts
@@ -1,4 +1,4 @@
-import { $, DiceType} from "@gi-tcg/core/data";
+import { $, DiceType } from "@gi-tcg/core/data";
 
 /**
  * @id 312018
@@ -13,15 +13,16 @@ define card {
   until "v4.4.0";
   cost DiceType.Void, 3;
   artifact {
-    on enter {
-      :generateDice(:self.master.element(), 1);
-      const elementKinds = new Set(
-        :queryAll($.my.character.includesDefeated).map((ch) => ch.element()),
-      );
-      if (elementKinds.size >= 3) {
-        :generateDice(DiceType.Omni, 1);
-      }
-    };
+    on staged,
+      :{
+        :generateDice(:self.master.element(), 1);
+        const elementKinds = new Set(
+          :queryAll($.my.character.includesDefeated).map((ch) => ch.element()),
+        );
+        if (elementKinds.size >= 3) {
+          :generateDice(DiceType.Omni, 1);
+        }
+      };
     on damaged {
       when :(
         !:e.target.isMine() && :self.master.isActive() && :e.getReaction()
@@ -61,9 +62,10 @@ define card {
   until "v4.4.0";
   cost DiceType.Aligned, 1;
   support place {
-    on enter {
-      :rerollDice(1);
-    };
+    on staged,
+      :{
+        :rerollDice(1);
+      };
     on roll {
       :e.addRerollCount(1);
     };

--- a/packages/data/src/old_versions/v4.5.0.gts
+++ b/packages/data/src/old_versions/v4.5.0.gts
@@ -1,8 +1,4 @@
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import { EmbersRekindled } from "../characters/pyro/abyss_lector_fathomless_flames.gts";
 import { HeronStrike } from "../characters/hydro/candace.gts";
 import { Wavestrider } from "../characters/electro/beidou.gts";
@@ -162,12 +158,13 @@ define card {
   support ally {
     associateExtension DisposedSupportCountExtension;
     variable experience, 0;
-    on enter {
-      :setVariable(
-        "experience",
-        Math.min(:getExtensionState().disposedSupportCount[:self.who], 6),
-      );
-    };
+    on staged,
+      :{
+        :setVariable(
+          "experience",
+          Math.min(:getExtensionState().disposedSupportCount[:self.who], 6),
+        );
+      };
     on dispose {
       when :( :e.entity.definition.type === "support" );
       :setVariable(

--- a/packages/data/src/old_versions/v4.5.0.gts
+++ b/packages/data/src/old_versions/v4.5.0.gts
@@ -158,13 +158,12 @@ define card {
   support ally {
     associateExtension DisposedSupportCountExtension;
     variable experience, 0;
-    on staged,
-      :{
-        :setVariable(
-          "experience",
-          Math.min(:getExtensionState().disposedSupportCount[:self.who], 6),
-        );
-      };
+    on staged {
+      :setVariable(
+        "experience",
+        Math.min(:getExtensionState().disposedSupportCount[:self.who], 6),
+      );
+    };
     on dispose {
       when :( :e.entity.definition.type === "support" );
       :setVariable(

--- a/packages/data/src/old_versions/v4.6.0.gts
+++ b/packages/data/src/old_versions/v4.6.0.gts
@@ -1,7 +1,4 @@
-import {
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType } from "@gi-tcg/core/data";
 import { UnderseaTreasure } from "../cards/event/other.gts";
 
 /**

--- a/packages/data/src/old_versions/v4.6.1.gts
+++ b/packages/data/src/old_versions/v4.6.1.gts
@@ -36,10 +36,9 @@ define card {
   until "v4.6.1";
   cost DiceType.Pyro, 3;
   talent Diluc {
-    on staged,
-      :{
-        :useSkill(SearingOnslaught);
-      };
+    on staged {
+      :useSkill(SearingOnslaught);
+    };
     on deductElementDiceSkill {
       when :(
         :e.action.skill.definition.id === SearingOnslaught &&
@@ -87,10 +86,9 @@ define card {
   until "v4.6.1";
   cost DiceType.Pyro, 2;
   talent Yoimiya {
-    on staged,
-      :{
-        :useSkill(NiwabiFiredance);
-      };
+    on staged {
+      :useSkill(NiwabiFiredance);
+    };
   };
 };
 
@@ -157,10 +155,9 @@ define card {
   cost DiceType.Cryo, 5;
   cost DiceType.Energy, 3;
   talent Qiqi {
-    on staged,
-      :{
-        :useSkill(AdeptusArtPreserverOfFortune);
-      };
+    on staged {
+      :useSkill(AdeptusArtPreserverOfFortune);
+    };
     on useSkill {
       when :( :e.skill.definition.id === AdeptusArtPreserverOfFortune );
       usage 2 {

--- a/packages/data/src/old_versions/v4.6.1.gts
+++ b/packages/data/src/old_versions/v4.6.1.gts
@@ -1,9 +1,4 @@
-import {
-  $,
-  DiceType,
-  DamageType,
-  type StatusHandle,
-} from "@gi-tcg/core/data";
+import { $, DiceType, DamageType, type StatusHandle } from "@gi-tcg/core/data";
 import { Diluc, SearingOnslaught } from "../characters/pyro/diluc.gts";
 import { NiwabiFiredance, Yoimiya } from "../characters/pyro/yoimiya.gts";
 import { KyoukaFuushi } from "../characters/hydro/kamisato_ayato.gts";
@@ -41,9 +36,10 @@ define card {
   until "v4.6.1";
   cost DiceType.Pyro, 3;
   talent Diluc {
-    on enter {
-      :useSkill(SearingOnslaught);
-    };
+    on staged,
+      :{
+        :useSkill(SearingOnslaught);
+      };
     on deductElementDiceSkill {
       when :(
         :e.action.skill.definition.id === SearingOnslaught &&
@@ -91,9 +87,10 @@ define card {
   until "v4.6.1";
   cost DiceType.Pyro, 2;
   talent Yoimiya {
-    on enter {
-      :useSkill(NiwabiFiredance);
-    };
+    on staged,
+      :{
+        :useSkill(NiwabiFiredance);
+      };
   };
 };
 
@@ -160,9 +157,10 @@ define card {
   cost DiceType.Cryo, 5;
   cost DiceType.Energy, 3;
   talent Qiqi {
-    on enter {
-      :useSkill(AdeptusArtPreserverOfFortune);
-    };
+    on staged,
+      :{
+        :useSkill(AdeptusArtPreserverOfFortune);
+      };
     on useSkill {
       when :( :e.skill.definition.id === AdeptusArtPreserverOfFortune );
       usage 2 {

--- a/packages/data/src/old_versions/v4.7.0.gts
+++ b/packages/data/src/old_versions/v4.7.0.gts
@@ -384,9 +384,10 @@ define card {
   until "v4.7.0";
   cost DiceType.Geo, 3;
   talent Albedo {
-    on enter {
-      :useSkill(AbiogenesisSolarIsotoma);
-    };
+    on staged,
+      :{
+        :useSkill(AbiogenesisSolarIsotoma);
+      };
     on increaseSkillDamage {
       when :( :query($.my.summon.def(SolarIsotoma)) && :e.viaPlungingAttack() );
       listenTo samePlayer;
@@ -409,9 +410,10 @@ define card {
   until "v4.7.0";
   cost DiceType.Geo, 5;
   talent Zhongli {
-    on enter {
-      :useSkill(DominusLapidisStrikingStone);
-    };
+    on staged,
+      :{
+        :useSkill(DominusLapidisStrikingStone);
+      };
     on increaseDamage {
       when :{
         return (
@@ -512,9 +514,10 @@ define card {
   until "v4.7.0";
   cost DiceType.Electro, 3;
   talent Cyno {
-    on enter {
-      :useSkill(SecretRiteChasmicSoulfarer);
-    };
+    on staged,
+      :{
+        :useSkill(SecretRiteChasmicSoulfarer);
+      };
     on increaseSkillDamage {
       when :{
         const status = :self.master.hasStatus(PactswornPathclearer)!;

--- a/packages/data/src/old_versions/v4.7.0.gts
+++ b/packages/data/src/old_versions/v4.7.0.gts
@@ -384,10 +384,9 @@ define card {
   until "v4.7.0";
   cost DiceType.Geo, 3;
   talent Albedo {
-    on staged,
-      :{
-        :useSkill(AbiogenesisSolarIsotoma);
-      };
+    on staged {
+      :useSkill(AbiogenesisSolarIsotoma);
+    };
     on increaseSkillDamage {
       when :( :query($.my.summon.def(SolarIsotoma)) && :e.viaPlungingAttack() );
       listenTo samePlayer;
@@ -410,10 +409,9 @@ define card {
   until "v4.7.0";
   cost DiceType.Geo, 5;
   talent Zhongli {
-    on staged,
-      :{
-        :useSkill(DominusLapidisStrikingStone);
-      };
+    on staged {
+      :useSkill(DominusLapidisStrikingStone);
+    };
     on increaseDamage {
       when :{
         return (
@@ -514,10 +512,9 @@ define card {
   until "v4.7.0";
   cost DiceType.Electro, 3;
   talent Cyno {
-    on staged,
-      :{
-        :useSkill(SecretRiteChasmicSoulfarer);
-      };
+    on staged {
+      :useSkill(SecretRiteChasmicSoulfarer);
+    };
     on increaseSkillDamage {
       when :{
         const status = :self.master.hasStatus(PactswornPathclearer)!;

--- a/packages/data/src/old_versions/v4.8.0.gts
+++ b/packages/data/src/old_versions/v4.8.0.gts
@@ -1,8 +1,4 @@
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import {
   Cyno,
   PactswornPathclearer,
@@ -28,9 +24,10 @@ define card {
   until "v4.8.0";
   cost DiceType.Electro, 3;
   talent Cyno {
-    on enter {
-      :useSkill(SecretRiteChasmicSoulfarer);
-    };
+    on staged,
+      :{
+        :useSkill(SecretRiteChasmicSoulfarer);
+      };
     on increaseSkillDamage {
       when :{
         const status = :self.master.hasStatus(PactswornPathclearer)!;

--- a/packages/data/src/old_versions/v4.8.0.gts
+++ b/packages/data/src/old_versions/v4.8.0.gts
@@ -24,10 +24,9 @@ define card {
   until "v4.8.0";
   cost DiceType.Electro, 3;
   talent Cyno {
-    on staged,
-      :{
-        :useSkill(SecretRiteChasmicSoulfarer);
-      };
+    on staged {
+      :useSkill(SecretRiteChasmicSoulfarer);
+    };
     on increaseSkillDamage {
       when :{
         const status = :self.master.hasStatus(PactswornPathclearer)!;

--- a/packages/data/src/old_versions/v5.0.0.gts
+++ b/packages/data/src/old_versions/v5.0.0.gts
@@ -275,9 +275,10 @@ define card {
   cost DiceType.Pyro, 3;
   cost DiceType.Energy, 2;
   talent EremiteScorchingLoremaster {
-    on enter {
-      :useSkill(SpiritOfOmensAwakeningPyroScorpion);
-    };
+    on staged,
+      :{
+        :useSkill(SpiritOfOmensAwakeningPyroScorpion);
+      };
   };
 };
 

--- a/packages/data/src/old_versions/v5.0.0.gts
+++ b/packages/data/src/old_versions/v5.0.0.gts
@@ -275,10 +275,9 @@ define card {
   cost DiceType.Pyro, 3;
   cost DiceType.Energy, 2;
   talent EremiteScorchingLoremaster {
-    on staged,
-      :{
-        :useSkill(SpiritOfOmensAwakeningPyroScorpion);
-      };
+    on staged {
+      :useSkill(SpiritOfOmensAwakeningPyroScorpion);
+    };
   };
 };
 

--- a/packages/data/src/old_versions/v5.2.0.gts
+++ b/packages/data/src/old_versions/v5.2.0.gts
@@ -150,10 +150,9 @@ define card {
   cost DiceType.Electro, 3;
   cost DiceType.Energy, 2;
   talent KukiShinobu {
-    on staged,
-      :{
-        :useSkill(GyoeiNarukamiKariyamaRite);
-      };
+    on staged {
+      :useSkill(GyoeiNarukamiKariyamaRite);
+    };
     on beforeDefeated {
       usage perRound, 1;
       :immune(1);

--- a/packages/data/src/old_versions/v5.2.0.gts
+++ b/packages/data/src/old_versions/v5.2.0.gts
@@ -150,9 +150,10 @@ define card {
   cost DiceType.Electro, 3;
   cost DiceType.Energy, 2;
   talent KukiShinobu {
-    on enter {
-      :useSkill(GyoeiNarukamiKariyamaRite);
-    };
+    on staged,
+      :{
+        :useSkill(GyoeiNarukamiKariyamaRite);
+      };
     on beforeDefeated {
       usage perRound, 1;
       :immune(1);

--- a/packages/data/src/old_versions/v5.3.0.gts
+++ b/packages/data/src/old_versions/v5.3.0.gts
@@ -58,10 +58,9 @@ define card {
   until "v5.3.0";
   cost DiceType.Geo, 3;
   talent Chiori {
-    on staged,
-      :{
-        :useSkill(FlutteringHasode);
-      };
+    on staged {
+      :useSkill(FlutteringHasode);
+    };
   };
 };
 

--- a/packages/data/src/old_versions/v5.3.0.gts
+++ b/packages/data/src/old_versions/v5.3.0.gts
@@ -1,7 +1,4 @@
-import {
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { DamageType, DiceType } from "@gi-tcg/core/data";
 import { DriftcloudWave, Skyladder } from "../characters/anemo/xianyun.gts";
 import {
   BattlelineDetonation,
@@ -61,9 +58,10 @@ define card {
   until "v5.3.0";
   cost DiceType.Geo, 3;
   talent Chiori {
-    on enter {
-      :useSkill(FlutteringHasode);
-    };
+    on staged,
+      :{
+        :useSkill(FlutteringHasode);
+      };
   };
 };
 

--- a/packages/data/src/old_versions/v5.4.0.gts
+++ b/packages/data/src/old_versions/v5.4.0.gts
@@ -1,8 +1,4 @@
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import {
   DandelionBreeze,
   FavoniusBladework,

--- a/packages/data/src/old_versions/v5.5.0.gts
+++ b/packages/data/src/old_versions/v5.5.0.gts
@@ -1,8 +1,4 @@
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import { BurningFlame, CatalyzingField, DendroCore } from "../commons.gts";
 
 /**

--- a/packages/data/src/old_versions/v5.6.0.gts
+++ b/packages/data/src/old_versions/v5.6.0.gts
@@ -1,8 +1,4 @@
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import {
   DominusLapidisStrikingStone,
   Zhongli,
@@ -105,9 +101,10 @@ define card {
   until "v5.6.0";
   cost DiceType.Geo, 5;
   talent Zhongli {
-    on enter {
-      :useSkill(DominusLapidisStrikingStone);
-    };
+    on staged,
+      :{
+        :useSkill(DominusLapidisStrikingStone);
+      };
     on increaseDamage {
       when :{
         return (
@@ -272,8 +269,9 @@ define card {
   cost DiceType.Electro, 4;
   cost DiceType.Energy, 2;
   talent RaidenShogun {
-    on enter {
-      :useSkill(SecretArtMusouShinsetsu);
-    };
+    on staged,
+      :{
+        :useSkill(SecretArtMusouShinsetsu);
+      };
   };
 };

--- a/packages/data/src/old_versions/v5.6.0.gts
+++ b/packages/data/src/old_versions/v5.6.0.gts
@@ -101,10 +101,9 @@ define card {
   until "v5.6.0";
   cost DiceType.Geo, 5;
   talent Zhongli {
-    on staged,
-      :{
-        :useSkill(DominusLapidisStrikingStone);
-      };
+    on staged {
+      :useSkill(DominusLapidisStrikingStone);
+    };
     on increaseDamage {
       when :{
         return (
@@ -269,9 +268,8 @@ define card {
   cost DiceType.Electro, 4;
   cost DiceType.Energy, 2;
   talent RaidenShogun {
-    on staged,
-      :{
-        :useSkill(SecretArtMusouShinsetsu);
-      };
+    on staged {
+      :useSkill(SecretArtMusouShinsetsu);
+    };
   };
 };

--- a/packages/data/src/old_versions/v5.7.0.gts
+++ b/packages/data/src/old_versions/v5.7.0.gts
@@ -1,9 +1,4 @@
-import {
-  $,
-  DamageType,
-  DiceType,
-  Reaction,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType, Reaction } from "@gi-tcg/core/data";
 import {
   Citlali,
   MamaloacosFrigidRainInEffect,
@@ -178,12 +173,13 @@ define card {
   until "v5.7.0";
   cost DiceType.Pyro, 2;
   talent Arlecchino {
-    on enter {
-      :characterStatus(BondOfLife, :self.master, {
-        overrideVariables: { usage: 3 },
-      });
-      // 消耗生命之契增伤的部分在被动技能 13147 里
-    };
+    on staged,
+      :{
+        :characterStatus(BondOfLife, :self.master, {
+          overrideVariables: { usage: 3 },
+        });
+        // 消耗生命之契增伤的部分在被动技能 13147 里
+      };
   };
 };
 

--- a/packages/data/src/old_versions/v5.7.0.gts
+++ b/packages/data/src/old_versions/v5.7.0.gts
@@ -173,13 +173,12 @@ define card {
   until "v5.7.0";
   cost DiceType.Pyro, 2;
   talent Arlecchino {
-    on staged,
-      :{
-        :characterStatus(BondOfLife, :self.master, {
-          overrideVariables: { usage: 3 },
-        });
-        // 消耗生命之契增伤的部分在被动技能 13147 里
-      };
+    on staged {
+      :characterStatus(BondOfLife, :self.master, {
+        overrideVariables: { usage: 3 },
+      });
+      // 消耗生命之契增伤的部分在被动技能 13147 里
+    };
   };
 };
 

--- a/packages/data/src/old_versions/v5.8.0.gts
+++ b/packages/data/src/old_versions/v5.8.0.gts
@@ -279,10 +279,9 @@ define card {
   until "v5.8.0";
   cost DiceType.Geo, 4;
   talent Ningguang {
-    on staged,
-      :{
-        :useSkill(JadeScreen);
-      };
+    on staged {
+      :useSkill(JadeScreen);
+    };
   };
 };
 
@@ -300,10 +299,9 @@ define card {
   until "v5.8.0";
   cost DiceType.Cryo, 4;
   talent Kaeya {
-    on staged,
-      :{
-        :useSkill(Frostgnaw);
-      };
+    on staged {
+      :useSkill(Frostgnaw);
+    };
     on useSkill {
       when :( :e.skill.definition.id === Frostgnaw );
       usage perRound, 1;
@@ -459,10 +457,9 @@ define card {
   until "v5.8.0";
   cost DiceType.Aligned, 2;
   support place {
-    on staged,
-      :{
-        :generateDice("randomElement", 1);
-      };
+    on staged {
+      :generateDice("randomElement", 1);
+    };
     on actionPhase {
       usage 2;
       :generateDice("randomElement", 1);

--- a/packages/data/src/old_versions/v5.8.0.gts
+++ b/packages/data/src/old_versions/v5.8.0.gts
@@ -279,9 +279,10 @@ define card {
   until "v5.8.0";
   cost DiceType.Geo, 4;
   talent Ningguang {
-    on enter {
-      :useSkill(JadeScreen);
-    };
+    on staged,
+      :{
+        :useSkill(JadeScreen);
+      };
   };
 };
 
@@ -299,9 +300,10 @@ define card {
   until "v5.8.0";
   cost DiceType.Cryo, 4;
   talent Kaeya {
-    on enter {
-      :useSkill(Frostgnaw);
-    };
+    on staged,
+      :{
+        :useSkill(Frostgnaw);
+      };
     on useSkill {
       when :( :e.skill.definition.id === Frostgnaw );
       usage perRound, 1;
@@ -457,9 +459,10 @@ define card {
   until "v5.8.0";
   cost DiceType.Aligned, 2;
   support place {
-    on enter {
-      :generateDice("randomElement", 1);
-    };
+    on staged,
+      :{
+        :generateDice("randomElement", 1);
+      };
     on actionPhase {
       usage 2;
       :generateDice("randomElement", 1);

--- a/packages/data/src/old_versions/v6.0.0.gts
+++ b/packages/data/src/old_versions/v6.0.0.gts
@@ -1,8 +1,4 @@
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import {
   AlldevouringNarwhal,
   AnomalousAnatomy,

--- a/packages/data/src/old_versions/v6.1.0.gts
+++ b/packages/data/src/old_versions/v6.1.0.gts
@@ -1,8 +1,4 @@
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import { DisposedSupportAndSummonsCountExtension } from "../cards/event/other.gts";
 import {
   Itzpapa,

--- a/packages/data/src/old_versions/v6.2.0.gts
+++ b/packages/data/src/old_versions/v6.2.0.gts
@@ -106,10 +106,9 @@ define card {
   until "v6.2.0";
   cost DiceType.Hydro, 3;
   talent KamisatoAyato {
-    on staged,
-      :{
-        :useSkill(KamisatoArtKyouka);
-      };
+    on staged {
+      :useSkill(KamisatoArtKyouka);
+    };
   };
 };
 
@@ -174,10 +173,9 @@ define card {
   until "v6.2.0";
   cost DiceType.Dendro, 4;
   talent Collei {
-    on staged,
-      :{
-        :useSkill(FloralBrush);
-      };
+    on staged {
+      :useSkill(FloralBrush);
+    };
   };
 };
 
@@ -232,10 +230,9 @@ define card {
     associateExtension NonInitialPlayedCardExtension;
     replaceDescription "[GCG_TOKEN_COUNTER]",
       ((_, { area }, ext) => ext.defIds[area.who].length);
-    on staged,
-      :{
-        :setVariable("supp", :getExtensionState().defIds[:self.who].length);
-      };
+    on staged {
+      :setVariable("supp", :getExtensionState().defIds[:self.who].length);
+    };
     on playCard {
       :setVariable("supp", :getExtensionState().defIds[:self.who].length);
     };

--- a/packages/data/src/old_versions/v6.2.0.gts
+++ b/packages/data/src/old_versions/v6.2.0.gts
@@ -1,8 +1,4 @@
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import {
   CoolcolorCapture,
   FramingFreezingPointComposition,
@@ -110,9 +106,10 @@ define card {
   until "v6.2.0";
   cost DiceType.Hydro, 3;
   talent KamisatoAyato {
-    on enter {
-      :useSkill(KamisatoArtKyouka);
-    };
+    on staged,
+      :{
+        :useSkill(KamisatoArtKyouka);
+      };
   };
 };
 
@@ -177,9 +174,10 @@ define card {
   until "v6.2.0";
   cost DiceType.Dendro, 4;
   talent Collei {
-    on enter {
-      :useSkill(FloralBrush);
-    };
+    on staged,
+      :{
+        :useSkill(FloralBrush);
+      };
   };
 };
 
@@ -234,9 +232,10 @@ define card {
     associateExtension NonInitialPlayedCardExtension;
     replaceDescription "[GCG_TOKEN_COUNTER]",
       ((_, { area }, ext) => ext.defIds[area.who].length);
-    on enter {
-      :setVariable("supp", :getExtensionState().defIds[:self.who].length);
-    };
+    on staged,
+      :{
+        :setVariable("supp", :getExtensionState().defIds[:self.who].length);
+      };
     on playCard {
       :setVariable("supp", :getExtensionState().defIds[:self.who].length);
     };

--- a/packages/data/src/old_versions/v6.3.0.gts
+++ b/packages/data/src/old_versions/v6.3.0.gts
@@ -1,7 +1,4 @@
-import {
-  $,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DiceType } from "@gi-tcg/core/data";
 import { StrictProhibited } from "../cards/support/place.gts";
 import {
   ConstantOffthecuffCookery,

--- a/packages/data/src/old_versions/v6.4.0.gts
+++ b/packages/data/src/old_versions/v6.4.0.gts
@@ -1,8 +1,4 @@
-import {
-  $,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, DamageType, DiceType } from "@gi-tcg/core/data";
 import {
   LetTheShowBegin,
   ShiningMiracle,

--- a/packages/data/src/old_versions/v6.5.0.gts
+++ b/packages/data/src/old_versions/v6.5.0.gts
@@ -252,10 +252,9 @@ define card {
     variable deductDiceTriggered, 0 {
       visible false;
     };
-    on staged,
-      :{
-        :characterStatus(Target, $.opp.active);
-      };
+    on staged {
+      :characterStatus(Target, $.opp.active);
+    };
     on deductOmniDiceSwitch {
       // 绒翼龙只在可以减费时生效
       when :(

--- a/packages/data/src/old_versions/v6.5.0.gts
+++ b/packages/data/src/old_versions/v6.5.0.gts
@@ -1,9 +1,4 @@
-import {
-  $,
-  type SkillHandle,
-  DamageType,
-  DiceType,
-} from "@gi-tcg/core/data";
+import { $, type SkillHandle, DamageType, DiceType } from "@gi-tcg/core/data";
 import {
   DarkgoldWolfbite,
   DarkgoldWolfbite01,
@@ -257,9 +252,10 @@ define card {
     variable deductDiceTriggered, 0 {
       visible false;
     };
-    on enter {
-      :characterStatus(Target, $.opp.active);
-    };
+    on staged,
+      :{
+        :characterStatus(Target, $.opp.active);
+      };
     on deductOmniDiceSwitch {
       // 绒翼龙只在可以减费时生效
       when :(

--- a/packages/data/src/old_versions/v6.6.0.gts
+++ b/packages/data/src/old_versions/v6.6.0.gts
@@ -20,9 +20,10 @@ define card {
   until "v6.6.0";
   cost DiceType.Dendro, 4;
   talent Tighnari {
-    on enter {
-      :useSkill(VijnanaphalaMine);
-    };
+    on staged,
+      :{
+        :useSkill(VijnanaphalaMine);
+      };
     on deductVoidDiceSkill {
       when :(
         :self.master.hasStatus(VijnanaSuffusion) && :e.isChargedAttack()

--- a/packages/data/src/old_versions/v6.6.0.gts
+++ b/packages/data/src/old_versions/v6.6.0.gts
@@ -20,10 +20,9 @@ define card {
   until "v6.6.0";
   cost DiceType.Dendro, 4;
   talent Tighnari {
-    on staged,
-      :{
-        :useSkill(VijnanaphalaMine);
-      };
+    on staged {
+      :useSkill(VijnanaphalaMine);
+    };
     on deductVoidDiceSkill {
       when :(
         :self.master.hasStatus(VijnanaSuffusion) && :e.isChargedAttack()

--- a/packages/test/__tests__/adventure.test.tsx
+++ b/packages/test/__tests__/adventure.test.tsx
@@ -16,11 +16,6 @@
 import { ref, setup, Character, State, Status, Card, $ } from "#test";
 import { AnAncientSacrificeOfSacredBrocade } from "@gi-tcg/data/internal/cards/event/other.gts";
 import { ChenyuVale } from "@gi-tcg/data/internal/cards/support/adventure.gts";
-import {
-  SkywardSonnet,
-  Venti,
-} from "@gi-tcg/data/internal/characters/anemo/venti.gts";
-import { Satiated } from "@gi-tcg/data/internal/commons.gts";
 import { test } from "vitest";
 
 test("adventure: basic", async () => {

--- a/packages/test/__tests__/nightmare_omen.test.tsx
+++ b/packages/test/__tests__/nightmare_omen.test.tsx
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 Piovium Labs
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { $, Attachment, Card, ref, setup, State, Support } from "#test";
+import { CostIncrease, Empowerment } from "@gi-tcg/data/internal/commons.gts";
+import {
+  LeaveItToMe,
+  Strategize,
+} from "@gi-tcg/data/internal/cards/event/other.gts";
+import { Paimon } from "@gi-tcg/data/internal/cards/support/ally.gts";
+import {
+  KuuvahkiExperimentalDesignBureau,
+  NightmareOmen,
+} from "@gi-tcg/data/internal/cards/support/place.gts";
+import { expect, test } from "vitest";
+
+// 支援区满，含有一张月矩力试验设计局，牌堆从上往下分别为牌1（赋能），牌2（赋能），牌3。
+// 打出噩梦的预兆，选择月矩力试验设计局弃置。
+// 期望结果为抓牌：牌1（赋能，费用增加），牌2（赋能）。
+test("nightmare omen stages before the replaced support is disposed", async () => {
+  const bureau = ref();
+  const card1 = ref();
+  const card2 = ref();
+  const card3 = ref();
+  const c = setup(
+    <State>
+      <Support my def={KuuvahkiExperimentalDesignBureau} ref={bureau} />
+      <Support my def={Paimon} />
+      <Support my def={Paimon} />
+      <Support my def={Paimon} />
+      <Card my pile def={Paimon} ref={card1}>
+        <Attachment def={Empowerment} />
+      </Card>
+      <Card my pile def={Strategize} ref={card2}>
+        <Attachment def={Empowerment} />
+      </Card>
+      <Card my pile def={LeaveItToMe} ref={card3} />
+      <Card my def={NightmareOmen} />
+    </State>,
+  );
+
+  await c.me.card(NightmareOmen, bureau);
+
+  expect(c.state.players[0].hands.map((card) => card.id)).toEqual(
+    expect.arrayContaining([card1.id, card2.id]),
+  );
+  expect(c.state.players[0].hands).toHaveLength(2);
+  expect(c.state.players[0].pile.map((card) => card.id)).toEqual([card3.id]);
+  c.expect($.my.attachment.def(Empowerment).on($.id(card1.id))).toBeExist();
+  c.expect($.my.attachment.def(CostIncrease).on($.id(card1.id))).toBeExist();
+  c.expect($.my.attachment.def(Empowerment).on($.id(card2.id))).toBeExist();
+  c.expect($.my.attachment.def(CostIncrease).on($.id(card2.id))).toNotExist();
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,26 +7,26 @@ settings:
 catalogs:
   default:
     '@gi-tcg/gts-language-client-code':
-      specifier: ^0.7.4
-      version: 0.7.4
+      specifier: ^0.7.5
+      version: 0.7.5
     '@gi-tcg/gts-language-server':
-      specifier: ^0.7.4
-      version: 0.7.4
+      specifier: ^0.7.5
+      version: 0.7.5
     '@gi-tcg/gts-runtime':
-      specifier: ^0.7.4
-      version: 0.7.4
+      specifier: ^0.7.5
+      version: 0.7.5
     '@gi-tcg/gts-transpiler':
-      specifier: ^0.7.4
-      version: 0.7.4
+      specifier: ^0.7.5
+      version: 0.7.5
     '@gi-tcg/gtsc':
-      specifier: ^0.7.4
-      version: 0.7.4
+      specifier: ^0.7.5
+      version: 0.7.5
     '@gi-tcg/prettier-plugin-gts':
-      specifier: ^0.7.4
-      version: 0.7.4
+      specifier: ^0.7.5
+      version: 0.7.5
     '@gi-tcg/unplugin-gts':
-      specifier: ^0.7.4
-      version: 0.7.4
+      specifier: ^0.7.5
+      version: 0.7.5
     '@unocss/preset-icons':
       specifier: ^66.3.3
       version: 66.3.3
@@ -88,10 +88,10 @@ importers:
         version: link:packages/config
       '@gi-tcg/prettier-plugin-gts':
         specifier: 'catalog:'
-        version: 0.7.4(prettier@3.9.5)
+        version: 0.7.5(prettier@3.9.5)
       '@gi-tcg/unplugin-gts':
         specifier: 'catalog:'
-        version: 0.7.4(esbuild@0.23.1)(rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(rollup@4.46.2)(unloader@0.9.0)(vite@8.0.8(@types/node@26.1.2)(esbuild@0.23.1)(jiti@2.7.0)(terser@5.31.1)(tsx@4.21.0))(webpack@5.104.1(@swc/core@1.15.33)(esbuild@0.23.1))
+        version: 0.7.5(esbuild@0.23.1)(rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(rollup@4.46.2)(unloader@0.9.0)(vite@8.0.8(@types/node@26.1.2)(esbuild@0.23.1)(jiti@2.7.0)(terser@5.31.1)(tsx@4.21.0))(webpack@5.104.1(@swc/core@1.15.33)(esbuild@0.23.1))
       '@microsoft/api-extractor':
         specifier: ^7.58.2
         version: 7.58.2(@types/node@26.1.2)
@@ -258,7 +258,7 @@ importers:
     dependencies:
       '@gi-tcg/gts-runtime':
         specifier: 'catalog:'
-        version: 0.7.4
+        version: 0.7.5
       '@gi-tcg/typings':
         specifier: workspace:*
         version: link:../typings
@@ -292,7 +292,7 @@ importers:
         version: link:../data
       '@gi-tcg/gts-transpiler':
         specifier: 'catalog:'
-        version: 0.7.4
+        version: 0.7.5
       esbuild-wasm:
         specifier: ^0.27.3
         version: 0.27.7
@@ -317,10 +317,10 @@ importers:
         version: link:../deck-builder
       '@gi-tcg/gts-language-client-code':
         specifier: 'catalog:'
-        version: 0.7.4(@codingame/monaco-vscode-extension-api@25.1.2)
+        version: 0.7.5(@codingame/monaco-vscode-extension-api@25.1.2)
       '@gi-tcg/gts-language-server':
         specifier: 'catalog:'
-        version: 0.7.4(@volar/language-service@2.4.28)(typescript@6.0.3)
+        version: 0.7.5(@volar/language-service@2.4.28)(typescript@6.0.3)
       '@gi-tcg/typings':
         specifier: workspace:*
         version: link:../typings
@@ -369,10 +369,10 @@ importers:
         version: link:../config
       '@gi-tcg/gts-transpiler':
         specifier: 'catalog:'
-        version: 0.7.4
+        version: 0.7.5
       '@gi-tcg/gtsc':
         specifier: 'catalog:'
-        version: 0.7.4(typescript@6.0.3)
+        version: 0.7.5(typescript@6.0.3)
       '@microsoft/tsdoc':
         specifier: ^0.14.2
         version: 0.14.2
@@ -390,7 +390,7 @@ importers:
         version: link:../core
       '@gi-tcg/gts-transpiler':
         specifier: 'catalog:'
-        version: 0.7.4
+        version: 0.7.5
     devDependencies:
       '@gi-tcg/data':
         specifier: workspace:*
@@ -2952,39 +2952,39 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@gi-tcg/gts-language-client-code@0.7.4':
-    resolution: {integrity: sha512-FAjgFX9owBGfxw1M8jE69OXm2mNK7S1GBBtuqygeONo/v0sjJm8Jz8agpA+zGbPyYoAim2XiS8nsduZLKF2GOQ==}
+  '@gi-tcg/gts-language-client-code@0.7.5':
+    resolution: {integrity: sha512-7rb9l3eYgFNlDqa+iUUYJkXjoLE/uxecic9/rZASQxRJmt3oCL/onxXmTeYNNeNDIkuwOtOU7sLt2U42kD+O9g==}
     peerDependencies:
       vscode: '*'
 
-  '@gi-tcg/gts-language-plugin@0.7.4':
-    resolution: {integrity: sha512-hA/uxIX2ZUV5KAowatBYc6HMbx9b8K3D0jY3z0fmgBKBKYgsajYYruTMtHsS47l0sw8TommOlDqv41kKpJ81Qw==}
+  '@gi-tcg/gts-language-plugin@0.7.5':
+    resolution: {integrity: sha512-/cc5Yx772micisuecsxbv5fSFEBc0JQZkn+2wY9z0l6zNVPZL7r6CwF2rdvRTv8uxy9MhcJn85XZ14RTp2NBHw==}
     peerDependencies:
       typescript: npm:@typescript/typescript6@^6.0.1
 
-  '@gi-tcg/gts-language-server@0.7.4':
-    resolution: {integrity: sha512-LWBKjrdu8YBlLzsACO1/qfkabPY79Cxklse0jSRvyZ2EIKZKtyzGXj5LHc47TVVlkpyvw7tU1rRWuAatwM+IdQ==}
+  '@gi-tcg/gts-language-server@0.7.5':
+    resolution: {integrity: sha512-MI5f8dH5cAlNqn7ckjaaXpKiK/iCsqYqzECU5O/g76wd5ehZis7hK48cxuLGHIRmdTRnZSoeieQ9aOMvyYPtZw==}
     hasBin: true
 
-  '@gi-tcg/gts-runtime@0.7.4':
-    resolution: {integrity: sha512-u0KB9CGmRES9pXaINqEauYIU2btvzkBduaioUiREBHicTrbV9pV0c05Ue/LgJ7dRprKTfsolTlMa3hkaFfSPGw==}
+  '@gi-tcg/gts-runtime@0.7.5':
+    resolution: {integrity: sha512-rn82eKiuYL3iMa3UccmzUOdCsvyDDJILudqOp2Tg0VyNspVDDmkvsAVxgc7Uhii1Y5f8TqYUSRW+Gp9Fq2rwiQ==}
 
-  '@gi-tcg/gts-transpiler@0.7.4':
-    resolution: {integrity: sha512-eIBwSBzWfPcWbYZKalZdCHW2KAj+ogIGK+u7+p/rTt08t2ubpSPEohfKQ9QIa6yOnIxShV/bHPNdHpyRibmYMg==}
+  '@gi-tcg/gts-transpiler@0.7.5':
+    resolution: {integrity: sha512-J7cAy/h/pzy5mdwGppmkfMKE2d5+ASOAftVlNKMXroPENjQgHHd2s2ocIt4KADEZwuvhQnV434MLXkw6S0YuOA==}
 
-  '@gi-tcg/gtsc@0.7.4':
-    resolution: {integrity: sha512-tLsU+lqCO2Zl3aDzbAEggZuNJ43HKqkPH7n/Rdv0KUwuuijqyTHdofFsv0aSljDEf+9ByqznG47SXyc7X4dTVw==}
+  '@gi-tcg/gtsc@0.7.5':
+    resolution: {integrity: sha512-ejphF2dTuFmHDybveP/4Nl84Mgskz4SwG5dlsk1IyJGKUyU6pMwJ0FxaK4L1Wjkxs9PJPIEPLGBPPPcJEXVoHw==}
     hasBin: true
     peerDependencies:
       typescript: npm:@typescript/typescript6@^6.0.1
 
-  '@gi-tcg/prettier-plugin-gts@0.7.4':
-    resolution: {integrity: sha512-cMpkj+74tpo72tum6wcixhKkOKqnjMMCo8RTcJtsmIsx4qnTlYheMSyNvoj4EKHRQecH56Y50hMY16iWnbbhPw==}
+  '@gi-tcg/prettier-plugin-gts@0.7.5':
+    resolution: {integrity: sha512-ewGvSicftsUMBRdKcZ/3OUN+MK8BDxF/s+TsvkTHAMAAzxn7f8CryP4AJM8Cf5RlS+3UWv/qOIU53+P7xHO9qQ==}
     peerDependencies:
       prettier: ^3.0.0
 
-  '@gi-tcg/unplugin-gts@0.7.4':
-    resolution: {integrity: sha512-eAR0l0OZrZNFR1/mUZM/0i7CdezzbaUNZzqSO2Cu2RJWK5+ED//vdmNirs9pv31mxoTwWwTMVOJQL+7qGYFC2w==}
+  '@gi-tcg/unplugin-gts@0.7.5':
+    resolution: {integrity: sha512-5Dc9bY9mXpxofKF4PbOJLUuyxrvOBBpCFtMq+cyVfiOVkRsX/x8Q8kc2D2WB7zjG7Z2iR4eEdwHVVVnVKwHO5A==}
     peerDependencies:
       '@rspack/core': ^1
       esbuild: '*'
@@ -10837,14 +10837,14 @@ snapshots:
   '@ffmpeg-installer/win32-x64@4.1.0':
     optional: true
 
-  '@gi-tcg/gts-language-client-code@0.7.4(@codingame/monaco-vscode-extension-api@25.1.2)':
+  '@gi-tcg/gts-language-client-code@0.7.5(@codingame/monaco-vscode-extension-api@25.1.2)':
     dependencies:
       remeda: 2.39.0
       vscode: '@codingame/monaco-vscode-extension-api@25.1.2'
 
-  '@gi-tcg/gts-language-plugin@0.7.4(typescript@6.0.3)':
+  '@gi-tcg/gts-language-plugin@0.7.5(typescript@6.0.3)':
     dependencies:
-      '@gi-tcg/gts-transpiler': 0.7.4
+      '@gi-tcg/gts-transpiler': 0.7.5
       '@volar/language-core': 2.4.28
       '@volar/typescript': 2.4.28
       typescript: 6.0.3
@@ -10852,10 +10852,10 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@gi-tcg/gts-language-server@0.7.4(@volar/language-service@2.4.28)(typescript@6.0.3)':
+  '@gi-tcg/gts-language-server@0.7.5(@volar/language-service@2.4.28)(typescript@6.0.3)':
     dependencies:
-      '@gi-tcg/gts-language-plugin': 0.7.4(typescript@6.0.3)
-      '@gi-tcg/gts-transpiler': 0.7.4
+      '@gi-tcg/gts-language-plugin': 0.7.5(typescript@6.0.3)
+      '@gi-tcg/gts-transpiler': 0.7.5
       '@volar/language-server': 2.4.28
       '@zenfs/core': 2.5.7
       path-browserify-esm: 1.0.6
@@ -10866,11 +10866,11 @@ snapshots:
       - babel-plugin-macros
       - typescript
 
-  '@gi-tcg/gts-runtime@0.7.4':
+  '@gi-tcg/gts-runtime@0.7.5':
     dependencies:
       ajv: 8.20.0
 
-  '@gi-tcg/gts-transpiler@0.7.4':
+  '@gi-tcg/gts-transpiler@0.7.5':
     dependencies:
       '@sveltejs/acorn-typescript': 1.0.10(acorn@8.16.0)
       '@types/estree': 1.0.9
@@ -10884,24 +10884,24 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@gi-tcg/gtsc@0.7.4(typescript@6.0.3)':
+  '@gi-tcg/gtsc@0.7.5(typescript@6.0.3)':
     dependencies:
-      '@gi-tcg/gts-language-plugin': 0.7.4(typescript@6.0.3)
+      '@gi-tcg/gts-language-plugin': 0.7.5(typescript@6.0.3)
       '@volar/typescript': 2.4.28
       typescript: 6.0.3
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@gi-tcg/prettier-plugin-gts@0.7.4(prettier@3.9.5)':
+  '@gi-tcg/prettier-plugin-gts@0.7.5(prettier@3.9.5)':
     dependencies:
-      '@gi-tcg/gts-transpiler': 0.7.4
+      '@gi-tcg/gts-transpiler': 0.7.5
       prettier: 3.9.5
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@gi-tcg/unplugin-gts@0.7.4(esbuild@0.23.1)(rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(rollup@4.46.2)(unloader@0.9.0)(vite@8.0.8(@types/node@26.1.2)(esbuild@0.23.1)(jiti@2.7.0)(terser@5.31.1)(tsx@4.21.0))(webpack@5.104.1(@swc/core@1.15.33)(esbuild@0.23.1))':
+  '@gi-tcg/unplugin-gts@0.7.5(esbuild@0.23.1)(rolldown@1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2))(rollup@4.46.2)(unloader@0.9.0)(vite@8.0.8(@types/node@26.1.2)(esbuild@0.23.1)(jiti@2.7.0)(terser@5.31.1)(tsx@4.21.0))(webpack@5.104.1(@swc/core@1.15.33)(esbuild@0.23.1))':
     dependencies:
-      '@gi-tcg/gts-transpiler': 0.7.4
+      '@gi-tcg/gts-transpiler': 0.7.5
       '@types/bun': 1.3.14
       rollup: 4.46.2
       unplugin: '@gytx/unplugin@3.1.0-patch.2'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ catalog:
   "@unocss/reset": ^66.3.3
   solid-js: ^1.9.12
   execa: ^9.6.1
-  "@gi-tcg/gts-transpiler": &GTS_VERSION "^0.7.4"
+  "@gi-tcg/gts-transpiler": &GTS_VERSION "^0.7.5"
   "@gi-tcg/gts-runtime": *GTS_VERSION
   "@gi-tcg/gtsc": *GTS_VERSION
   "@gi-tcg/unplugin-gts": *GTS_VERSION


### PR DESCRIPTION
<!--
Thank you for your contribution! To help us review your pull request more efficiently, please fill out the following sections:

- Clearly describe what you changed and why.
- Explain how you verified that your changes are correct.
-->

Fixes #819.

## What Changed

The `on enter` of Equipment and Support are not a triggered skill; instead it is a "inline" operation of playing action.

- **Phase I**: Support `on staged` special structure for specifying additinal playing action of a support and equipment card.
- **Phase II**: Complete the refactorization of `adventure`, specifically `Tonatiuh`'s first triggering.
- **Phase III**: Rename `on enter` to `on selfEnter` (sync with `selfDispose`), and remove the entering event emission of moving card from off-stage to on-stage.

This PR supports Phase I.

## How to Prove It Works

Add a UT.

<!-- Explain how you tested your changes. Did you run unit tests, integration tests, or manual verifications? Please provide steps or evidence that demonstrate your change is correct. -->
