### PR TITLE
fix(core): play or onEnter (Phase II, adventure-specific)

### DIFF
--- a/packages/core/src/gts/vm_impl/card.ts
+++ b/packages/core/src/gts/vm_impl/card.ts
@@ -153,8 +153,9 @@ export class CardModel extends InitiativeSkillModel implements ICaller {
           direct: true,
         });
       }
+      const self = c.self.cast<"support">();
       const newEntity = c.moveEntity(
-        c.self.cast<"support">(),
+        self,
         { who: c.self.who, type: "supports" },
         "createSupport",
       );
@@ -162,6 +163,8 @@ export class CardModel extends InitiativeSkillModel implements ICaller {
         for (const operation of stagedOperations) {
           operation(c);
         }
+      } else {
+        c.dispose(self, { direct: true, reason: "overflow" });
       }
     };
   }

--- a/packages/core/src/gts/vm_impl/card.ts
+++ b/packages/core/src/gts/vm_impl/card.ts
@@ -73,6 +73,7 @@ import type {
   InitiativeSkillEventArg,
 } from "../../base/skill";
 import type { Writable } from "../../utils";
+import type { Character } from "../../runtime/reactive/character";
 
 const SATIATED_ID = 303300 as StatusHandle;
 
@@ -133,8 +134,8 @@ export class CardModel extends InitiativeSkillModel implements ICaller {
   setEquipmentPlayAction(): void {
     const stagedOperations = this.innerModel?.stagedOperations ?? [];
     this.action = function (c) {
-      for (const ch of c.eventArg.targets) {
-        ch.equip(c.self);
+      for (const ch of c.eventArg.targets as Character<any>[]) {
+        ch.equip(c.self.cast<"equipment">());
       }
       for (const operation of stagedOperations) {
         operation(c);
@@ -152,13 +153,15 @@ export class CardModel extends InitiativeSkillModel implements ICaller {
           direct: true,
         });
       }
-      c.moveEntity(
+      const newEntity = c.moveEntity(
         c.self.cast<"support">(),
         { who: c.self.who, type: "supports" },
         "createSupport",
       );
-      for (const operation of stagedOperations) {
-        operation(c);
+      if (newEntity) {
+        for (const operation of stagedOperations) {
+          operation(c);
+        }
       }
     };
   }
@@ -479,7 +482,7 @@ export class CardViewModel extends InitiativeSkillViewModel
       model.setSupportPlayAction();
       if (model.innerModel.tags.includes("adventureSpot")) {
         // 冒险地点入场时触发一次冒险后
-        model.postOperations.push((c) => {
+        model.innerModel.stagedOperations.push((c) => {
           c.emitEvent("onAdventure", c.rawState, c.self.latest());
         });
       }

--- a/packages/core/src/gts/vm_impl/card.ts
+++ b/packages/core/src/gts/vm_impl/card.ts
@@ -477,6 +477,12 @@ export class CardViewModel extends InitiativeSkillViewModel
       model.innerModel = EntityViewModel.parse(subView, "support", model);
       model.tags.push(...supportTags);
       model.setSupportPlayAction();
+      if (model.innerModel.tags.includes("adventureSpot")) {
+        // 冒险地点入场时触发一次冒险后
+        model.postOperations.push((c) => {
+          c.emitEvent("onAdventure", c.rawState, c.self.latest());
+        });
+      }
     }),
     legend: h.simpleAttribute({
       uniqueKey: "legend",

--- a/packages/core/src/runtime/skill_context.ts
+++ b/packages/core/src/runtime/skill_context.ts
@@ -1082,9 +1082,14 @@ export class SkillContext<Meta extends ContextMetaBase> {
     area: EntityArea,
     reason: MoveEntityM["reason"] = "other",
   ) {
-    const { newState } = this.callAndEmit("insertEntityOnStage", this.get(state).latest(), area, {
-      moveReason: reason,
-    });
+    const { newState } = this.callAndEmit(
+      "insertEntityOnStage",
+      this.get(state).latest(),
+      area,
+      {
+        moveReason: reason,
+      },
+    );
     if (newState) {
       return this.get(newState.id);
     } else {

--- a/packages/core/src/runtime/skill_context.ts
+++ b/packages/core/src/runtime/skill_context.ts
@@ -1082,9 +1082,14 @@ export class SkillContext<Meta extends ContextMetaBase> {
     area: EntityArea,
     reason: MoveEntityM["reason"] = "other",
   ) {
-    this.callAndEmit("insertEntityOnStage", this.get(state).latest(), area, {
+    const { newState } = this.callAndEmit("insertEntityOnStage", this.get(state).latest(), area, {
       moveReason: reason,
     });
+    if (newState) {
+      return this.get(newState.id);
+    } else {
+      return null;
+    }
   }
   summon(
     id: SummonHandle,

--- a/packages/core/src/skill_executor.ts
+++ b/packages/core/src/skill_executor.ts
@@ -477,7 +477,6 @@ export class SkillExecutor {
         const currentSpot = hisSupports.find((et) =>
           et.definition.tags.includes("adventureSpot"),
         );
-        let selectCardInfo: SelectCardInfo | null = null;
         if (currentSpot) {
           this.mutate({
             type: "modifyEntityVar",
@@ -486,12 +485,16 @@ export class SkillExecutor {
             value: currentSpot.variables.exp + 1,
             direction: "increase",
           });
-        } else if (hisSupports.length < this.state.config.maxSupportsCount) {
+          await this.handleEvent([
+            "onAdventure",
+            new EntityEventArg(this.state, currentSpot),
+          ]);
+        } else {
           const spots = this.state.data.entities
             .values()
             .filter((d) => d.tags.includes("adventureSpot"))
             .toArray();
-          selectCardInfo = {
+          const selectCardInfo: SelectCardInfo = {
             type: "requestPlayCard",
             cards: spots,
             targets: [],
@@ -502,17 +505,6 @@ export class SkillExecutor {
             selectCardInfo,
           );
           await this.handleEvent(...events);
-        }
-        const adventureSpot = this.state.players[arg.who].supports.find((et) =>
-          et.definition.tags.includes("adventureSpot"),
-        );
-        if (adventureSpot) {
-          await this.handleEvent([
-            "onAdventure",
-            new EntityEventArg(this.state, adventureSpot),
-          ]);
-        }
-        if (selectCardInfo) {
           await this.handleEvent([
             "onSelectCard",
             new SelectCardEventArg(this.state, arg.who, selectCardInfo),

--- a/packages/data/src/cards/event/food.gts
+++ b/packages/data/src/cards/event/food.gts
@@ -859,7 +859,7 @@ define card {
  * 我方下2次冒险或结束阶段时，治疗所附属角色1点。
  */
 define status {
-  id 303323 as private ChenyuBrewInEffect;
+  id 303323 as ChenyuBrewInEffect;
   since "v6.1.0";
   usage 2;
   on adventure {

--- a/packages/data/src/cards/support/adventure.gts
+++ b/packages/data/src/cards/support/adventure.gts
@@ -166,10 +166,9 @@ define card {
     // 第一次冒险后实为打出效果
     on staged {
       :convertDice(DiceType.Omni, 1);
-    }
+    };
     on adventure {
-      when :( :getVariable("exp") !== 1);
-      :convertDice(DiceType.Omni, 1);
+      when :( :getVariable("exp") !== 1 );
     };
     on adventure {
       when :( :getVariable("exp") >= 2 );

--- a/packages/data/src/cards/support/adventure.gts
+++ b/packages/data/src/cards/support/adventure.gts
@@ -169,6 +169,7 @@ define card {
     };
     on adventure {
       when :( :getVariable("exp") !== 1 );
+      :convertDice(DiceType.Omni, 1);
     };
     on adventure {
       when :( :getVariable("exp") >= 2 );

--- a/packages/data/src/cards/support/adventure.gts
+++ b/packages/data/src/cards/support/adventure.gts
@@ -163,7 +163,12 @@ define card {
   undiscoverable;
   support place {
     adventureSpot;
+    // 第一次冒险后实为打出效果
+    on staged {
+      :convertDice(DiceType.Omni, 1);
+    }
     on adventure {
+      when :( :getVariable("exp") !== 1);
       :convertDice(DiceType.Omni, 1);
     };
     on adventure {

--- a/packages/test/__tests__/adventure.test.tsx
+++ b/packages/test/__tests__/adventure.test.tsx
@@ -13,13 +13,31 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { ref, setup, Character, State, Status, Card, $, DiceCount } from "#test";
+import {
+  ref,
+  setup,
+  Character,
+  State,
+  Status,
+  Card,
+  $,
+  DiceCount,
+  Support,
+  Equipment,
+} from "#test";
+import { VeteransVisage } from "@gi-tcg/data/internal/cards/equipment/artifacts.gts";
+import {
+  ChenyuBrew,
+  ChenyuBrewInEffect,
+} from "@gi-tcg/data/internal/cards/event/food.gts";
 import { AnAncientSacrificeOfSacredBrocade } from "@gi-tcg/data/internal/cards/event/other.gts";
 import {
   ChenyuVale,
   TheChasm,
   Tonatiuh,
 } from "@gi-tcg/data/internal/cards/support/adventure.gts";
+import { Paimon } from "@gi-tcg/data/internal/cards/support/ally.gts";
+import { AquabreezeBlessingWaterburst } from "@gi-tcg/data/internal/cards/support/blessing.gts";
 import { DiceType } from "@gi-tcg/typings";
 import { describe, expect, test } from "vitest";
 
@@ -56,5 +74,83 @@ describe("adventure", () => {
     await c.me.card(AnAncientSacrificeOfSacredBrocade);
     await c.me.selectCard(Tonatiuh);
     expect(c.state.players[0].dice).toEqual([DiceType.Omni]);
-  })
+  });
+
+  describe("adventure (exp=1), spot 'triggered' before status", () => {
+    test("tonatiuh", async () => {
+      const c = setup(
+        <State>
+          <Character opp alive={0} health={0} />
+          <Character opp alive={0} health={0} />
+          <Character opp active health={1} />
+          <Character my active>
+          <Status my def={ChenyuBrewInEffect} />
+          </Character>
+          <Support my def={AquabreezeBlessingWaterburst} />
+          <Card my def={AnAncientSacrificeOfSacredBrocade} />
+          <DiceCount my count={2} type={DiceType.Cryo} />
+        </State>
+      );
+      // 冒险
+      await c.me.card(AnAncientSacrificeOfSacredBrocade);
+      await c.me.selectCard(Tonatiuh);
+      // 先触发转换
+      expect(c.state.players[0].dice).toEqual([DiceType.Omni]);
+      // 沉玉茶露治疗，触发水风幻变击倒仅存角色，获得胜利
+      expect(c.state.phase).toBe("gameEnd");
+      expect(c.state.winner).toBe(0);
+    })
+
+    test("chasm", async () => {
+      const c = setup(
+        <State>
+          <Character my active health={1}>
+            <Equipment my def={VeteransVisage} v={{ count: 1 }} />
+            <Status my def={ChenyuBrewInEffect} />
+          </Character>
+          <Card my def={AnAncientSacrificeOfSacredBrocade} />
+        </State>
+      );
+      // 冒险
+      await c.me.card(AnAncientSacrificeOfSacredBrocade);
+      await c.me.selectCard(TheChasm);
+      // 先触发生成手牌，然后触发沉玉茶露治疗，再触发老兵抽牌
+      c.expect($.my.active).toHaveVariable({ health: 2 });
+      c.expect($.def(VeteransVisage)).toHaveVariable({ count: 2 });
+      c.expect($.my.hand).toBeCount(1);
+      c.expect($.my.pile).toBeCount(4);
+    })
+  });
+
+  test("adventure (exp>=2), spot triggered after status", async () => {
+    const c = setup(
+      <State>
+        <Support my def={ChenyuVale} v={{ exp: 1 }} />
+        <Character my active health={1}>
+          <Equipment my def={VeteransVisage} v={{ count: 1 }} />
+          <Status my def={ChenyuBrewInEffect} />
+        </Character>
+        <Card my def={AnAncientSacrificeOfSacredBrocade} />
+        <Card my def={Paimon} />
+        <Card my def={Paimon} />
+        <Card my def={Paimon} />
+        <Card my def={Paimon} />
+        <Card my def={Paimon} />
+        <Card my def={Paimon} />
+        <Card my def={Paimon} />
+        <Card my def={Paimon} />
+        <Card my def={Paimon} />
+        <Card my pile def={Paimon} />
+      </State>,
+    );
+    // 冒险
+    await c.me.card(AnAncientSacrificeOfSacredBrocade);
+    // 先触发沉玉茶露，治疗，再触发老兵抽牌
+    c.expect($.my.active).toHaveVariable({ health: 2 });
+    c.expect($.def(VeteransVisage)).toHaveVariable({ count: 2 });
+    c.expect($.my.hand).toBeCount(10);
+    // 再触发沉玉谷生成手牌，此时手牌已满不再生成沉玉茶露
+    c.expect($.my.def(ChenyuVale)).toHaveVariable({ exp: 2 });
+    c.expect($.my.hand.def(ChenyuBrew)).toNotExist();
+  });
 });

--- a/packages/test/__tests__/adventure.test.tsx
+++ b/packages/test/__tests__/adventure.test.tsx
@@ -38,6 +38,7 @@ import {
 } from "@gi-tcg/data/internal/cards/support/adventure.gts";
 import { Paimon } from "@gi-tcg/data/internal/cards/support/ally.gts";
 import { AquabreezeBlessingWaterburst } from "@gi-tcg/data/internal/cards/support/blessing.gts";
+import { MastersOfTheNightwind } from "@gi-tcg/data/internal/cards/support/place.gts";
 import { DiceType } from "@gi-tcg/typings";
 import { describe, expect, test } from "vitest";
 
@@ -74,6 +75,34 @@ describe("adventure", () => {
     await c.me.card(AnAncientSacrificeOfSacredBrocade);
     await c.me.selectCard(Tonatiuh);
     expect(c.state.players[0].dice).toEqual([DiceType.Omni]);
+  });
+
+  test("support area full: selecting an adventure only triggers on select card", async () => {
+    const c = setup(
+      <State>
+        <Character my active health={1}>
+          <Status my def={ChenyuBrewInEffect} />
+        </Character>
+        <Support my def={MastersOfTheNightwind} />
+        <Support my def={Paimon} />
+        <Support my def={Paimon} />
+        <Support my def={Paimon} />
+        <Card my def={AnAncientSacrificeOfSacredBrocade} />
+        <DiceCount my count={2} type={DiceType.Cryo} />
+      </State>,
+    );
+
+    await c.me.card(AnAncientSacrificeOfSacredBrocade);
+    await c.me.selectCard(Tonatiuh);
+
+    // 冒险地点未能入场，但挑选后触发
+    c.expect($.my.support.def(MastersOfTheNightwind)).toHaveVariable({
+      intuition: 3,
+    });
+    c.expect($.my.support.def(Tonatiuh)).toNotExist();
+    // 天蛇船的首次冒险（入场）效果不触发
+    expect(c.state.players[0].dice).toEqual([DiceType.Cryo]);
+    c.expect($.my.active).toHaveVariable({ health: 1 });
   });
 
   describe("adventure (exp=1), spot 'triggered' before status", () => {

--- a/packages/test/__tests__/adventure.test.tsx
+++ b/packages/test/__tests__/adventure.test.tsx
@@ -93,7 +93,9 @@ describe("adventure", () => {
     );
 
     await c.me.card(AnAncientSacrificeOfSacredBrocade);
+    c.expect($.my.hand).toNotExist();
     await c.me.selectCard(Tonatiuh);
+    c.expect($.my.hand).toNotExist();
 
     // 冒险地点未能入场，但挑选后触发
     c.expect($.my.support.def(MastersOfTheNightwind)).toHaveVariable({
@@ -103,6 +105,7 @@ describe("adventure", () => {
     // 天蛇船的首次冒险（入场）效果不触发
     expect(c.state.players[0].dice).toEqual([DiceType.Cryo]);
     c.expect($.my.active).toHaveVariable({ health: 1 });
+    
   });
 
   describe("adventure (exp=1), spot 'triggered' before status", () => {

--- a/packages/test/__tests__/adventure.test.tsx
+++ b/packages/test/__tests__/adventure.test.tsx
@@ -13,18 +13,48 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { ref, setup, Character, State, Status, Card, $ } from "#test";
+import { ref, setup, Character, State, Status, Card, $, DiceCount } from "#test";
 import { AnAncientSacrificeOfSacredBrocade } from "@gi-tcg/data/internal/cards/event/other.gts";
-import { ChenyuVale } from "@gi-tcg/data/internal/cards/support/adventure.gts";
-import { test } from "vitest";
+import {
+  ChenyuVale,
+  TheChasm,
+  Tonatiuh,
+} from "@gi-tcg/data/internal/cards/support/adventure.gts";
+import { DiceType } from "@gi-tcg/typings";
+import { describe, expect, test } from "vitest";
 
-test("adventure: basic", async () => {
-  const c = setup(
-    <State>
-      <Card my def={AnAncientSacrificeOfSacredBrocade} />
-    </State>,
-  );
-  await c.me.card(AnAncientSacrificeOfSacredBrocade);
-  await c.me.selectCard(ChenyuVale);
-  c.expect($.my.support.def(ChenyuVale)).toHaveVariable({ exp: 1 });
+describe("adventure", () => {
+  test("chenyuvale basic", async () => {
+    const c = setup(
+      <State>
+        <Card my def={AnAncientSacrificeOfSacredBrocade} />
+      </State>,
+    );
+    await c.me.card(AnAncientSacrificeOfSacredBrocade);
+    await c.me.selectCard(ChenyuVale);
+    c.expect($.my.support.def(ChenyuVale)).toHaveVariable({ exp: 1 });
+  });
+
+  test("chasm basic", async () => {
+    const c = setup(
+      <State>
+        <Card my def={AnAncientSacrificeOfSacredBrocade} />
+      </State>,
+    );
+    await c.me.card(AnAncientSacrificeOfSacredBrocade);
+    await c.me.selectCard(TheChasm);
+    c.expect($.my.pile).toBeCount(5);
+  });
+
+  test("tonatiuh basic", async () => {
+    const c = setup(
+      <State>
+        <Card my def={AnAncientSacrificeOfSacredBrocade} />
+        <DiceCount my count={2} type={DiceType.Cryo} />
+      </State>,
+    );
+    await c.me.card(AnAncientSacrificeOfSacredBrocade);
+    await c.me.selectCard(Tonatiuh);
+    expect(c.state.players[0].dice).toEqual([DiceType.Omni]);
+  })
 });

--- a/packages/test/__tests__/game_end.test.tsx
+++ b/packages/test/__tests__/game_end.test.tsx
@@ -18,10 +18,7 @@ test("game end during onActionPhase does not request an action", async () => {
       <Character opp health={0} alive={0} />
     </State>,
   );
-
-  await expect(c.stepToNextAction()).rejects.toThrow(
-    "Game ended, no more action",
-  );
+  await c.stepToNextAction();
   expect(c.state.phase).toBe("gameEnd");
   expect(c.state.winner).toBe(0);
 });

--- a/packages/test/src/controller.ts
+++ b/packages/test/src/controller.ts
@@ -34,11 +34,7 @@ import {
   PlayerConfig,
   QueryFn,
 } from "@gi-tcg/core";
-import {
-  CardHandle,
-  CharacterHandle,
-  SkillHandle,
-} from "@gi-tcg/core/data";
+import { CardHandle, CharacterHandle, SkillHandle } from "@gi-tcg/core/data";
 import { Ref } from "./setup";
 import { StatesMatcher } from "./matcher";
 
@@ -387,7 +383,7 @@ export class TestController {
   _start() {
     this.game.start().then(
       () => {
-        this.stepping.reject(new Error("Game ended, no more action"));
+        this.stepping.resolve();
       },
       (error) => {
         this.stepping.reject(error);

--- a/packages/test/src/controller.ts
+++ b/packages/test/src/controller.ts
@@ -37,7 +37,6 @@ import {
 import {
   CardHandle,
   CharacterHandle,
-  DiceType,
   SkillHandle,
 } from "@gi-tcg/core/data";
 import { Ref } from "./setup";
@@ -121,10 +120,6 @@ class IoController {
     return rpc.request.value.action;
   }
 
-  private generateCost(length: number) {
-    return Array.from({ length }, () => DiceType.Omni);
-  }
-
   skill(id: SkillHandle, ...targets: Ref[]): IoResultPromise {
     return IoResultPromise.create(this.controller, () => {
       const actions = this.listAvailableActions();
@@ -139,13 +134,10 @@ class IoController {
         throw new Error(`You cannot use skill ${id} (with given targets)`);
       }
       const action = actions[chosenActionIndex];
-      const usedDice = this.generateCost(
-        action.requiredCost.reduce(
-          (a, { type, count }) => a + (type === DiceType.Energy ? 0 : count),
-          0,
-        ),
-      );
-      const response: ActionResponse = { chosenActionIndex, usedDice };
+      const response: ActionResponse = {
+        chosenActionIndex,
+        usedDice: action.autoSelectedDice,
+      };
       this.awaitingRpc!.resolve(response);
     });
   }
@@ -174,13 +166,10 @@ class IoController {
         throw new Error(`You cannot play card ${cardId} (with given targets)`);
       }
       const action = actions[chosenActionIndex];
-      const usedDice = this.generateCost(
-        action.requiredCost.reduce(
-          (a, { type, count }) => a + (type === DiceType.Energy ? 0 : count),
-          0,
-        ),
-      );
-      const response: ActionResponse = { chosenActionIndex, usedDice };
+      const response: ActionResponse = {
+        chosenActionIndex,
+        usedDice: action.autoSelectedDice,
+      };
       this.awaitingRpc!.resolve(response);
     });
   }
@@ -206,8 +195,11 @@ class IoController {
       if (chosenActionIndex === -1) {
         throw new Error(`You cannot tune card ${cardId}`);
       }
-      const usedDice = this.generateCost(1);
-      const response: ActionResponse = { chosenActionIndex, usedDice };
+      const action = actions[chosenActionIndex];
+      const response: ActionResponse = {
+        chosenActionIndex,
+        usedDice: action.autoSelectedDice,
+      };
       this.awaitingRpc!.resolve(response);
     });
   }
@@ -234,13 +226,10 @@ class IoController {
         throw new Error(`You cannot switch to character ${characterId}`);
       }
       const action = actions[chosenActionIndex];
-      const usedDice = this.generateCost(
-        action.requiredCost.reduce(
-          (a, { type, count }) => a + (type === DiceType.Energy ? 0 : count),
-          0,
-        ),
-      );
-      const response: ActionResponse = { chosenActionIndex, usedDice };
+      const response: ActionResponse = {
+        chosenActionIndex,
+        usedDice: action.autoSelectedDice,
+      };
       this.awaitingRpc!.resolve(response);
     });
   }
@@ -254,7 +243,11 @@ class IoController {
       if (chosenActionIndex === -1) {
         throw new Error("You cannot declare end (wtf?)");
       }
-      const response: ActionResponse = { chosenActionIndex, usedDice: [] };
+      const action = actions[chosenActionIndex];
+      const response: ActionResponse = {
+        chosenActionIndex,
+        usedDice: action.autoSelectedDice,
+      };
       this.awaitingRpc!.resolve(response);
     });
   }

--- a/packages/test/src/setup.ts
+++ b/packages/test/src/setup.ts
@@ -177,6 +177,7 @@ export namespace DiceCount {
     my?: boolean;
     opp?: boolean;
     count: number;
+    type?: DiceType;
   }
 }
 export function DiceCount(props: DiceCount.Prop): JSX.Element {
@@ -272,7 +273,10 @@ export function setup(state: JSX.Element): TestController {
       }
       continue;
     } else if (comp === DiceCount) {
-      const diceArr = Array.from({ length: prop.count }, () => DiceType.Omni);
+      const diceArr = Array.from(
+        { length: prop.count },
+        () => prop.type ?? DiceType.Omni,
+      );
       if (prop.my) {
         players[0].dice = diceArr;
       }
@@ -516,13 +520,11 @@ export function setup(state: JSX.Element): TestController {
 
   const extensions = data.extensions
     .values()
-    .map(
-      (def): ExtensionState => ({
-        [StateSymbol]: "extension",
-        definition: def,
-        state: def.initialState,
-      }),
-    )
+    .map((def): ExtensionState => ({
+      [StateSymbol]: "extension",
+      definition: def,
+      state: def.initialState,
+    }))
     .toArray();
   const gameState: GameState = {
     [StateSymbol]: "game",


### PR DESCRIPTION
<!--
Thank you for your contribution! To help us review your pull request more efficiently, please fill out the following sections:

- Clearly describe what you changed and why.
- Explain how you verified that your changes are correct.
-->

## What Changed

Follows #836, part of #837.

Adventure spot should:
- For the first time effect, inlined as `on staged` part of playing skill (so it executed before other listening skill)
- Emit `onAdventure` as part of playing skill
- For the rest effects, triggered after other listening skill

After this PR, there should not have things that specifying `selfEnter` of a support/equipment.

<!-- Describe the changes you made. What functionality, code, or files did you update? Why was this change necessary? -->

## How to Prove It Works

More UTs.

<!-- Explain how you tested your changes. Did you run unit tests, integration tests, or manual verifications? Please provide steps or evidence that demonstrate your change is correct. -->
