### PR TITLE
fix(data): LightningStrikeProbe should attached to skillCaller

### DIFF
--- a/packages/data/src/characters/electro/thunder_manifestation.gts
+++ b/packages/data/src/characters/electro/thunder_manifestation.gts
@@ -87,7 +87,7 @@ define combatStatus {
   id 124021 as LightningStrikeProbe;
   on useSkill {
     usage perRound, 1;
-    :characterStatus(LightningRod, $.my.active);
+    :characterStatus(LightningRod, :e.skillCaller.cast<"character">());
   };
 };
 


### PR DESCRIPTION
<!--
Thank you for your contribution! To help us review your pull request more efficiently, please fill out the following sections:

- Clearly describe what you changed and why.
- Explain how you verified that your changes are correct.
-->

## What Changed

<!-- Describe the changes you made. What functionality, code, or files did you update? Why was this change necessary? -->

## How to Prove It Works

No. Missing UT: Strike Probe should attached to Gaming when he use elemental skill

<!-- Explain how you tested your changes. Did you run unit tests, integration tests, or manual verifications? Please provide steps or evidence that demonstrate your change is correct. -->
