### PR TITLE
fix(data-code-analyzer): include old version dependencies

### DIFF
--- a/packages/data-code-analyzer/scripts/index.ts
+++ b/packages/data-code-analyzer/scripts/index.ts
@@ -27,9 +27,7 @@ export const base = fileURLToPath(new URL("../../data", import.meta.url));
 const project = new TcgDataProject();
 const filepaths: string[] = [];
 for await (const filepath of glob(`${base}/src/**/*.gts`)) {
-  if (!filepath.includes(`${path.sep}old_versions${path.sep}`)) {
-    filepaths.push(filepath);
-  }
+  filepaths.push(filepath);
 }
 
 for (const filepath of filepaths.sort()) {


### PR DESCRIPTION
Include legacy GTS files in the analyzer input so their entity dependency relationships are generated.

Verification: pnpm --filter @gi-tcg/data-code-analyzer build