### PR TITLE
refactor(core): unify official version resolver

### DIFF
--- a/docs/development/data/README.md
+++ b/docs/development/data/README.md
@@ -70,7 +70,7 @@ define card {
 };
 ```
 
-`@gi-tcg/data` 的默认导出为 `(version?) => GameData`。省略参数时取得最新版本；传入版本号则由 `resolveOfficialVersion` 选中在该版本有效的定义。详见[游戏版本](./version.md)。
+`@gi-tcg/data` 的默认导出为 `(version?) => GameData`。省略参数时取得最新版本；传入版本号则由 `createOfficialVersionResolver` 选中在该版本有效的定义。详见[游戏版本](./version.md)。
 
 ## 官方卡牌数据自动化维护
 

--- a/packages/core/__tests__/version.test.ts
+++ b/packages/core/__tests__/version.test.ts
@@ -1,9 +1,14 @@
-import { test, expect } from "vitest";
-import { resolveOfficialVersion, type WithVersionInfo } from "../src/base/version";
+import { test, expect, describe } from "vitest";
+import {
+  createOfficialVersionResolver,
+  type Version,
+  type WithVersionInfo,
+} from "../src/base/version";
+import type { VersionResolver } from "../src/data";
 import { toSortedBy } from "@gi-tcg/utils";
 
 test("find version", () => {
-  const versions: (WithVersionInfo & { id: number })[] = [
+  const versions: any[] = [
     {
       id: 999,
       version: {
@@ -35,11 +40,75 @@ test("find version", () => {
       },
     },
   ];
-  expect(resolveOfficialVersion(versions, "v3.3.0")).toBeNull();
-  expect(resolveOfficialVersion(versions, "v3.5.0")?.id).toBe(400);
-  expect(resolveOfficialVersion(versions, "v4.0.0")?.id).toBe(400);
-  expect(resolveOfficialVersion(versions, "v4.1.0")?.id).toBe(410);
-  expect(resolveOfficialVersion(versions, "v4.2.0")?.id).toBe(999);
+  const resolved = (base: Version) =>
+    createOfficialVersionResolver(base)(versions);
+  expect(resolved("v3.3.0")).toBeNull();
+  expect(resolved("v3.5.0")?.id).toBe(400);
+  expect(resolved("v4.0.0")?.id).toBe(400);
+  expect(resolved("v4.1.0")?.id).toBe(410);
+  expect(resolved("v4.2.0")?.id).toBe(999);
+});
+
+describe("resolveManuallySelectedOfficialVersion", () => {
+  const resolvedVersion = (resolver: VersionResolver, id: number) => {
+    const candidates: any[] = [
+      {
+        id,
+        selectedVersion: "old",
+        version: {
+          from: "official",
+          value: { predicate: "until", version: "v3.5.0" },
+        },
+      },
+      {
+        id,
+        selectedVersion: "new",
+        version: {
+          from: "official",
+          value: { predicate: "since", version: "v3.5.0" },
+        },
+      },
+    ];
+    return resolver(candidates)?.selectedVersion as "old" | "new" | undefined;
+  };
+
+  test("manually selected versions w/o dependencies", () => {
+    const resolver = createOfficialVersionResolver("v4.2.0", { 1: "v3.5.0" });
+    expect(resolvedVersion(resolver, 1)).toBe("old");
+    expect(resolvedVersion(resolver, 2)).toBe("new");
+  });
+
+  test("manually selected versions propagate through dependencies", () => {
+    const resolver = createOfficialVersionResolver("v4.2.0", { 1: "v3.5.0" }, [
+      { id: 1, dependencies: [2, 4] },
+      { id: 2, dependencies: [3] },
+      { id: 4, dependencies: [3] },
+    ]);
+    expect(resolvedVersion(resolver, 2)).toBe("old");
+    expect(resolvedVersion(resolver, 3)).toBe("old");
+  });
+
+  test("explicit versions override propagated versions and propagate onward", () => {
+    const resolver = createOfficialVersionResolver(
+      "v3.5.0",
+      { 1: "v3.5.0", 2: "v4.2.0" },
+      [
+        { id: 1, dependencies: [2] },
+        { id: 2, dependencies: [3] },
+      ],
+    );
+    expect(resolvedVersion(resolver, 2)).toBe("new");
+    expect(resolvedVersion(resolver, 3)).toBe("new");
+  });
+
+  test("conflicting propagated versions throw", () => {
+    expect(() =>
+      createOfficialVersionResolver("v3.5.0", { 1: "v3.5.0", 2: "v4.2.0" }, [
+        { id: 1, dependencies: [3] },
+        { id: 2, dependencies: [3] },
+      ]),
+    ).toThrow("Entity 3 has conflicting propagated versions: v3.5.0 vs v4.2.0");
+  });
 });
 
 test("sortedBy", () => {

--- a/packages/core/src/base/version.ts
+++ b/packages/core/src/base/version.ts
@@ -70,7 +70,7 @@ export const CURRENT_VERSION = VERSIONS[lastVersionIndex];
 
 export const versionLt = (a: Version, b: Version): boolean => {
   return VERSIONS.indexOf(a) < VERSIONS.indexOf(b);
-}
+};
 
 export interface OfficialVersionData {
   readonly predicate: "since" | "until";
@@ -107,9 +107,9 @@ export function versionCompare(a: Version, b: Version) {
   return versionIdxMap[a] - versionIdxMap[b];
 }
 
-export function resolveOfficialVersion<T extends WithVersionInfo>(
+function resolveOfficialVersion<T extends WithVersionInfo>(
   candidates: readonly T[],
-  requiredVersion: Version = CURRENT_VERSION,
+  requiredVersion: Version,
 ): T | null {
   const since = candidates.find(
     ({ version }) =>
@@ -137,15 +137,61 @@ export function resolveOfficialVersion<T extends WithVersionInfo>(
   return until[0] ?? null;
 }
 
-export function resolveManuallySelectedOfficialVersion(
-  versions: Record<number, Version>,
+export interface DependencyInfo {
+  readonly id: number;
+  readonly dependencies: readonly number[];
+}
+
+export function createOfficialVersionResolver(
   baseVersion: Version = CURRENT_VERSION,
+  versions: Record<number, Version> = {},
+  dependencies: readonly DependencyInfo[] = [],
 ): VersionResolver {
+  const dependencyMap = new Map(
+    dependencies.map(({ id, dependencies }) => [id, dependencies] as const),
+  );
+  const propagatedVersions = new Map<number, Version>();
+
+  const propagateVersion = (
+    id: number,
+    version: Version,
+    isRoot: boolean,
+    visiting: Set<number>,
+  ) => {
+    if (!isRoot && versions[id]) {
+      return;
+    }
+    if (!isRoot) {
+      const propagatedVersion = propagatedVersions.get(id);
+      if (propagatedVersion) {
+        if (propagatedVersion !== version) {
+          throw new Error(
+            `Entity ${id} has conflicting propagated versions: ${propagatedVersion} vs ${version}`,
+          );
+        }
+        return;
+      }
+      propagatedVersions.set(id, version);
+    }
+    if (visiting.has(id)) {
+      return;
+    }
+    visiting.add(id);
+    for (const dependencyId of dependencyMap.get(id) ?? []) {
+      propagateVersion(dependencyId, version, false, visiting);
+    }
+    visiting.delete(id);
+  };
+
+  for (const [id, version] of Object.entries(versions)) {
+    propagateVersion(Number(id), version, true, new Set());
+  }
+
   return <T extends WithVersionInfo>(candidates: readonly T[]) => {
     const id = candidates[0].id;
-    const version = versions[id] ?? baseVersion;
+    const version = versions[id] ?? propagatedVersions.get(id) ?? baseVersion;
     return resolveOfficialVersion(candidates, version);
-  }
+  };
 }
 
 export const DEFAULT_VERSION_INFO: VersionInfo = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,8 +41,7 @@ export {
   type VersionInfo,
   VERSIONS,
   CURRENT_VERSION,
-  resolveOfficialVersion,
-  resolveManuallySelectedOfficialVersion,
+  createOfficialVersionResolver,
 } from "./base/version";
 export * from "./query";
 export {

--- a/packages/custom-data-loader/src/index.ts
+++ b/packages/custom-data-loader/src/index.ts
@@ -15,7 +15,7 @@
 
 import {
   type GameData,
-  resolveOfficialVersion,
+  createOfficialVersionResolver,
   type SkillDefinition,
   type Version,
   playSkillOfCard,
@@ -154,7 +154,7 @@ export class CustomDataLoader {
         }
         return customDataItems[0] ?? null;
       },
-      (items) => resolveOfficialVersion(items, this.version),
+      createOfficialVersionResolver(this.version),
     );
     const standaloneSkills: CustomSkill[] = [];
     const customData: CustomData = {

--- a/packages/data/src/end.ts
+++ b/packages/data/src/end.ts
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import { resolveOfficialVersion, type Version } from "@gi-tcg/core";
+import { createOfficialVersionResolver, type Version } from "@gi-tcg/core";
 import { registry, scope } from "./begin.ts";
 
 scope.end();
@@ -22,5 +22,5 @@ registry.freeze();
 export { registry };
 
 export default (version?: Version) => {
-  return registry.resolve((x) => resolveOfficialVersion(x, version));
+  return registry.resolve(createOfficialVersionResolver(version));
 };


### PR DESCRIPTION
## Summary

- replace standalone official-version resolution functions with a configurable resolver factory
- propagate explicit entity versions through dependency graphs and reject conflicts
- update consumers and cover propagation, overrides, and conflict cases

## Validation
- pnpm --filter @gi-tcg/core test
- pnpm --filter @gi-tcg/core check