### PR TITLE
fix(data): abortPreview behavior adjustment

### DIFF
--- a/packages/data/src/characters/hydro/alldevouring_narwhal.gts
+++ b/packages/data/src/characters/hydro/alldevouring_narwhal.gts
@@ -214,7 +214,7 @@ define skill {
     ? Math.min(Math.floor(st.getVariable("extraMaxHealth") / 3), 3)
     : 0;
   :damage(DamageType.Hydro, 1 + extraDmg);
-  const [card] = :discardMaxCostHands(1);
+  const [card] = :discardMaxCostHands(1, { allowPreview: true });
   if (card) {
     :emitCustomEvent(StarfallShowerDisposeCard, card.latest());
   }

--- a/packages/data/src/old_versions/v4.7.0.gts
+++ b/packages/data/src/old_versions/v4.7.0.gts
@@ -155,7 +155,7 @@ define skill {
     ? Math.min(Math.floor(st.getVariable("extraMaxHealth") / 3), 5)
     : 0;
   :damage(DamageType.Hydro, 1 + extraDmg);
-  const [card] = :discardMaxCostHands(1);
+  const [card] = :discardMaxCostHands(1, { allowPreview: true });
   if (card) {
     if (:self.hasEquipment(LightlessFeeding)) {
       :heal(card.diceCost(), :self);

--- a/packages/data/src/old_versions/v4.8.0.gts
+++ b/packages/data/src/old_versions/v4.8.0.gts
@@ -120,7 +120,7 @@ define skill {
     ? Math.min(Math.floor(st.getVariable("extraMaxHealth") / 3), 4)
     : 0;
   :damage(DamageType.Hydro, 1 + extraDmg);
-  const [card] = :discardMaxCostHands(1);
+  const [card] = :discardMaxCostHands(1, { allowPreview: true });
   if (card) {
     if (:self.hasEquipment(LightlessFeeding)) {
       :heal(card.diceCost(), :self);

--- a/packages/data/src/old_versions/v6.0.0.gts
+++ b/packages/data/src/old_versions/v6.0.0.gts
@@ -235,7 +235,7 @@ define combatStatus {
  */
 define card {
   id 124051 as BonecrunchersEnergyBlock;
-  since "v4.7.0";
+  until "v6.0.0";
   undiscoverable;
   filter :(
     !:query($.my.combatStatus.def(BonecrunchersEnergyBlockCombatStatus))

--- a/packages/data/src/old_versions/v6.0.0.gts
+++ b/packages/data/src/old_versions/v6.0.0.gts
@@ -4,6 +4,7 @@ import {
   AnomalousAnatomy,
 } from "../characters/hydro/alldevouring_narwhal.gts";
 import { FestiveFires } from "../characters/pyro/xinyan.gts";
+import { BonecrunchersEnergyBlockCombatStatus } from "../cards/event/other.gts";
 
 /**
  * @id 115113
@@ -224,6 +225,25 @@ define combatStatus {
       :setVariable("extraMaxHealth", 0);
     }
   };
+};
+
+/**
+ * @id 124051
+ * @name 噬骸能量块
+ * @description
+ * 随机舍弃1张当前元素骰费用最高的手牌，生成1个我方出战角色类型的元素骰。（每回合最多打出1张）
+ */
+define card {
+  id 124051 as BonecrunchersEnergyBlock;
+  since "v4.7.0";
+  undiscoverable;
+  filter :(
+    !:query($.my.combatStatus.def(BonecrunchersEnergyBlockCombatStatus))
+  );
+  :discardMaxCostHands(1);
+  const activeCh = :query($.my.active)!;
+  :generateDice(activeCh.element(), 1);
+  :combatStatus(BonecrunchersEnergyBlockCombatStatus);
 };
 
 /**

--- a/packages/data/src/old_versions/v6.1.0.gts
+++ b/packages/data/src/old_versions/v6.1.0.gts
@@ -22,14 +22,7 @@ import {
   SoloistsSolicitation,
   SoloistsSolicitationOusia,
 } from "../characters/hydro/furina.gts";
-import {
-  AllIsAsh,
-  Arlecchino,
-  BalemoonRising,
-  InvitationToABeheading,
-  TheBalemoonAloneMayKnowPassive01,
-  TheBalemoonAloneMayKnowPassive03,
-} from "../characters/pyro/arlecchino.gts";
+import { Arlecchino } from "../characters/pyro/arlecchino.gts";
 import { BondOfLife } from "../commons.gts";
 import { SingYourHeartOutInEffect } from "../cards/event/food.gts";
 


### PR DESCRIPTION
- 迸落星雨 always bypass core restriction of abort preview
- 噬骸能量块 only abort preview since v6.1

<!--
Thank you for your contribution! To help us review your pull request more efficiently, please fill out the following sections:

- Clearly describe what you changed and why.
- Explain how you verified that your changes are correct.
-->

## What Changed

<!-- Describe the changes you made. What functionality, code, or files did you update? Why was this change necessary? -->

## How to Prove It Works

<!-- Explain how you tested your changes. Did you run unit tests, integration tests, or manual verifications? Please provide steps or evidence that demonstrate your change is correct. -->
