### PR TITLE
feat(server, web-client): use protobuf base64 for game messages

### DIFF
--- a/packages/server/src/rooms/rooms.controller.ts
+++ b/packages/server/src/rooms/rooms.controller.ts
@@ -26,10 +26,10 @@ import {
   UnauthorizedException,
 } from "@nestjs/common";
 import {
+  IsBase64,
   IsBoolean,
   IsInt,
   IsNumber,
-  IsObject,
   IsOptional,
   Length,
   Max,
@@ -39,7 +39,6 @@ import {
 } from "class-validator";
 import { RoomsService, type PlayerId } from "./rooms.service";
 import { Guest, User, UserOrGuest } from "../auth/user.decorator";
-import type { RpcMethod, RpcResponse, RpcResponsePayloadOf } from "@gi-tcg/typings";
 import { VERSIONS, type Version } from "@gi-tcg/core";
 import { DeckDto } from "../decks/decks.controller";
 import { Public } from "../auth/auth.guard";
@@ -139,8 +138,8 @@ export class PlayerActionResponseDto {
   @IsInt()
   id!: number;
 
-  @IsObject()
-  response!: RpcResponsePayloadOf<RpcMethod>;
+  @IsBase64()
+  response!: string;
 }
 
 @Controller("rooms")

--- a/packages/server/src/rooms/rooms.service.ts
+++ b/packages/server/src/rooms/rooms.service.ts
@@ -30,16 +30,24 @@ import {
   type Notification,
   type PlayerIO,
   type RpcRequest,
+  type RpcResponse,
   serializeGameStateLog,
   CORE_VERSION,
   VERSIONS,
-  RpcResponse,
   CURRENT_VERSION,
   type Version,
   type GameState,
   setAsyncContext,
 } from "@gi-tcg/core";
-import { dispatchRpc, type Deck } from "@gi-tcg/typings";
+import {
+  base64Decode,
+  base64Encode,
+  dispatchRpc,
+  Notification as PbNotification,
+  RpcRequest as PbRpcRequest,
+  RpcResponse as PbRpcResponse,
+  type Deck,
+} from "@gi-tcg/typings";
 import getData from "@gi-tcg/data";
 import { flip } from "@gi-tcg/utils";
 import {
@@ -149,7 +157,7 @@ export interface SSEInitialized {
 
 export interface SSENotification {
   type: "notification";
-  data: Notification;
+  data: string;
 }
 export interface SSEError {
   type: "error";
@@ -161,7 +169,7 @@ export interface SSERpc {
   data: {
     id: number;
     timer: RpcTimer;
-    request: RpcRequest;
+    request: string;
   } | null;
 }
 export interface SSEOppRpc {
@@ -257,7 +265,9 @@ class Player implements PlayerIOWithError {
         data: {
           id: this._rpcResolver.id,
           timer: this.getTimer()!,
-          request: this._rpcResolver.request,
+          request: base64Encode(
+            PbRpcRequest.encode(this._rpcResolver.request).finish(),
+          ),
         },
       };
     } else {
@@ -282,13 +292,24 @@ class Player implements PlayerIOWithError {
       console.error(this._rpcResolver, response);
       throw new NotFoundException(`Rpc id not match`);
     }
-    this._rpcResolver.resolve(response.response);
+    try {
+      const rpcResponse = PbRpcResponse.decode(base64Decode(response.response));
+      if (
+        !rpcResponse.response ||
+        rpcResponse.response.$case !== this._rpcResolver.request.request?.$case
+      ) {
+        throw new Error("RPC response method mismatch");
+      }
+      this._rpcResolver.resolve(rpcResponse);
+    } catch {
+      throw new BadRequestException("Invalid RPC response");
+    }
   }
 
   notify(notification: Notification) {
     this.notificationSseSource.next({
       type: "notification",
-      data: notification,
+      data: base64Encode(PbNotification.encode(notification).finish()),
     });
     this._mutationExtraTimeout += 0.5 * notification.mutation.length;
   }

--- a/packages/typings/src/index.ts
+++ b/packages/typings/src/index.ts
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 export * from "./common_enums";
+export { base64Decode, base64Encode } from "@bufbuild/protobuf/wire";
 
 export {
   UseSkillAction,

--- a/packages/web-client/src/pages/Room.tsx
+++ b/packages/web-client/src/pages/Room.tsx
@@ -31,7 +31,13 @@ import {
 import axios, { AxiosError } from "axios";
 import "@gi-tcg/web-ui-core/style.css";
 import EventSourceStream from "@server-sent-stream/web";
-import { type Notification, type RpcRequest } from "@gi-tcg/typings";
+import {
+  base64Decode,
+  base64Encode,
+  Notification,
+  RpcRequest,
+  RpcResponse,
+} from "@gi-tcg/typings";
 import { Client, createClient, WebUiPlayerIO } from "@gi-tcg/web-ui-core";
 import { useMobile } from "../App";
 import { Dynamic } from "solid-js/web";
@@ -58,7 +64,7 @@ interface RpcTimer {
 interface ActionRequestPayload {
   id: number;
   timer: RpcTimer;
-  request: RpcRequest;
+  request: string;
 }
 
 const SSE_RECONNECT_TIMEOUT = 30 * 1000;
@@ -236,7 +242,8 @@ export default function Room() {
     }
     lastRpcId = payload.id;
     setCurrentMyTimer(payload.timer);
-    const response = await io.rpc(payload.request).catch(() => void 0);
+    const request = RpcRequest.decode(base64Decode(payload.request));
+    const response = await io.rpc(request).catch(() => void 0);
     if (!response || lastRpcId !== payload.id) {
       return;
     }
@@ -246,7 +253,7 @@ export default function Room() {
         `rooms/${id}/players/${playerId}/actionResponse`,
         {
           id: payload.id,
-          response,
+          response: base64Encode(RpcResponse.encode(response).finish()),
         },
       );
       await reply;
@@ -328,7 +335,7 @@ export default function Room() {
           break;
         }
         case "notification": {
-          const notification: Notification = payload.data;
+          const notification = Notification.decode(base64Decode(payload.data));
           playerIo()?.notify(notification);
           break;
         }
@@ -378,15 +385,16 @@ export default function Room() {
           break;
         }
         case "notification": {
-          const notification: Notification = payload.data;
+          const notification = Notification.decode(base64Decode(payload.data));
           oppPlayerIo()?.notify(notification);
           break;
         }
         case "rpc": {
           const rpc: ActionRequestPayload | null = payload.data;
           if (rpc) {
+            const request = RpcRequest.decode(base64Decode(rpc.request));
             oppPlayerIo()
-              ?.rpc(rpc.request)
+              ?.rpc(request)
               .catch(() => void 0);
           } else {
             oppPlayerIo()?.cancelRpc?.();


### PR DESCRIPTION
## Summary

- encode SSE notification and RPC request payloads as Protobuf + Base64
- encode web-client action responses as Protobuf + Base64 and validate/decode them on the server
- keep room control events and non-game REST APIs on their existing JSON protocol

## Wire format

- notification: `{ type: "notification", data: "<base64 Notification>" }`
- rpc: `{ type: "rpc", data: { id, timer, request: "<base64 RpcRequest>" } }`
- actionResponse: `{ id, response: "<base64 RpcResponse>" }`

## Validation

- `pnpm --filter @gi-tcg/typings build`
- `pnpm --filter @gi-tcg/server check`
- `pnpm --filter @gi-tcg/web-client check`
- `pnpm --filter @gi-tcg/web-client build`
- Protobuf/Base64 round-trip checks for Notification, RpcRequest, and RpcResponse
- Prettier and `git diff --check`