### PR TITLE
feat(core): make reactive states queryable

### DIFF
--- a/packages/core/__tests__/query.test-d.ts
+++ b/packages/core/__tests__/query.test-d.ts
@@ -8,6 +8,8 @@ import { $ } from "../src/query/dollar";
 import { type IsEqual, typingInfo, type IQuery, type InferResult } from "../src/query/utils";
 import type { CharacterHandle, SummonHandle } from "../src/data";
 import type { AttachmentHandle, ExEntityType } from "../src/data/type";
+import type { ContextMetaBase } from "../src/runtime/skill_context";
+import type { RxEntityState } from "../src/runtime/reactive";
 
 declare const infer: <Q extends IQuery>(q: Q) => InferResult<Q>;
 
@@ -36,6 +38,14 @@ expectEntityType<"character">()($.character);
 expectEntityType<"character">()($.active);
 expectEntityType<"character">()($.prev);
 expectEntityType<"character">()($.next);
+
+// reactive states are queries for their own entity id
+declare const reactiveCharacter: RxEntityState<ContextMetaBase, "character">;
+declare const reactiveStatus: RxEntityState<ContextMetaBase, "status">;
+expectEntityType<"character">()(reactiveCharacter);
+expectEntityType<"character">()($.character.intersection(reactiveCharacter));
+expectEntityType<"status">()($.typeStatus.at(reactiveCharacter));
+expectEntityType<"character">()($.character.has(reactiveStatus));
 
 expectEntityType<"eventCard" | "equipment" | "support" | "attachment">()(
   $.vHand,

--- a/packages/core/__tests__/query.test.ts
+++ b/packages/core/__tests__/query.test.ts
@@ -6,25 +6,6 @@ import {
   stringifySExpr,
 } from "../src/query";
 import type { AttachmentHandle } from "../src/data/type";
-import {
-  LatestStateSymbol,
-  ReactiveStateBase,
-  ReactiveStateSymbol,
-} from "../src/runtime/reactive/base";
-
-class TestReactiveState extends ReactiveStateBase {
-  readonly id = 42;
-  get [ReactiveStateSymbol]() {
-    return "character" as const;
-  }
-  get [LatestStateSymbol]() {
-    return {};
-  }
-}
-
-test("reactive state builds an id query", () => {
-  expect(queryToExpression(new TestReactiveState())).toEqual(["id", 42]);
-});
 
 test("'Fluent API' building tests", () => {
   expect(

--- a/packages/core/__tests__/query.test.ts
+++ b/packages/core/__tests__/query.test.ts
@@ -6,6 +6,25 @@ import {
   stringifySExpr,
 } from "../src/query";
 import type { AttachmentHandle } from "../src/data/type";
+import {
+  LatestStateSymbol,
+  ReactiveStateBase,
+  ReactiveStateSymbol,
+} from "../src/runtime/reactive/base";
+
+class TestReactiveState extends ReactiveStateBase {
+  readonly id = 42;
+  get [ReactiveStateSymbol]() {
+    return "character" as const;
+  }
+  get [LatestStateSymbol]() {
+    return {};
+  }
+}
+
+test("reactive state builds an id query", () => {
+  expect(queryToExpression(new TestReactiveState())).toEqual(["id", 42]);
+});
 
 test("'Fluent API' building tests", () => {
   expect(

--- a/packages/core/src/runtime/reactive/base.ts
+++ b/packages/core/src/runtime/reactive/base.ts
@@ -14,6 +14,14 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import type { ExEntityType } from "../../data/type";
+import type { SExprSchema } from "../../query/expr_schema";
+import {
+  toExpression,
+  toExpressionUnordered,
+  type IUnorderedQuery,
+  type typingInfo,
+  type TypingInfoBase,
+} from "../../query/utils";
 
 export const ReactiveStateSymbol: unique symbol = Symbol("ReactiveState");
 export type ReactiveStateSymbol = typeof ReactiveStateSymbol;
@@ -34,14 +42,21 @@ export interface ExtraInfo<Ty extends ExEntityType> {
     | (Ty extends "eventCard" | "support" | "equipment" | "attachment"
         ? "hands" | "pile"
         : never)
-    | "disposedEntities";
+    | "removedEntities";
 }
 
-
-export abstract class ReactiveStateBase {
+export abstract class ReactiveStateBase implements IUnorderedQuery {
+  declare [typingInfo]: TypingInfoBase;
+  abstract readonly id: number;
   abstract get [ReactiveStateSymbol](): ExEntityType;
   declare [RawStateSymbol]: object;
   abstract get [LatestStateSymbol](): object;
+  [toExpressionUnordered](): SExprSchema.UnorderedQuery {
+    return ["id", this.id];
+  }
+  [toExpression](): SExprSchema.Query {
+    return this[toExpressionUnordered]();
+  }
   cast<Ty extends ExEntityType>(): this & {
     readonly [ReactiveStateSymbol]: Ty;
   } {

--- a/packages/core/src/runtime/reactive/index.ts
+++ b/packages/core/src/runtime/reactive/index.ts
@@ -26,6 +26,7 @@ import {
 } from "./base";
 import type { ExEntityState, ExEntityType } from "../../data/type";
 import { Attachment, type TypedAttachment } from "./attachment";
+import type { IUnorderedQuery } from "../../query/utils";
 
 type ReactiveClassCtor = new (
   skillContext: SkillContext<any>,
@@ -52,7 +53,12 @@ type ReactiveState<
           ? TypedAttachment<Meta>
           : Ty extends EntityType
             ? TypedEntity<Meta, Ty, Extra>
-            : never)
+            : never) &
+      IUnorderedQuery<{
+        type: Ty;
+        areaType: Extra["areaType"];
+        variables: Extra["variables"];
+      }>
   : never;
 
 export type RxEntityState<

--- a/packages/core/src/runtime/skill_context.ts
+++ b/packages/core/src/runtime/skill_context.ts
@@ -640,9 +640,8 @@ export class SkillContext<Meta extends ContextMetaBase> {
   ): RxEntityState<Meta, TypeT>[] {
     if (Array.isArray(q)) {
       return q.map((s) => this.get(s));
-    } else if (typeof q !== "function" && ReactiveStateSymbol in q) {
-      // Reactive states are also queries, but direct-target APIs should keep
-      // their existing eager-target semantics.
+    } else if (ReactiveStateSymbol in q) {
+      // Reactive states are also IQuery, check them before toExpression
       return [q as RxEntityState<Meta, TypeT>];
     } else if (typeof q === "function" || toExpression in q) {
       return this.queryAll(q) as RxEntityState<Meta, TypeT>[];

--- a/packages/core/src/runtime/skill_context.ts
+++ b/packages/core/src/runtime/skill_context.ts
@@ -640,6 +640,10 @@ export class SkillContext<Meta extends ContextMetaBase> {
   ): RxEntityState<Meta, TypeT>[] {
     if (Array.isArray(q)) {
       return q.map((s) => this.get(s));
+    } else if (typeof q !== "function" && ReactiveStateSymbol in q) {
+      // Reactive states are also queries, but direct-target APIs should keep
+      // their existing eager-target semantics.
+      return [q as RxEntityState<Meta, TypeT>];
     } else if (typeof q === "function" || toExpression in q) {
       return this.queryAll(q) as RxEntityState<Meta, TypeT>[];
     } else {

--- a/packages/data/src/cards/equipment/weapon/pole.gts
+++ b/packages/data/src/cards/equipment/weapon/pole.gts
@@ -121,7 +121,7 @@ define card {
         return !!:query(
           $.my.combatStatus
             .tag("shield")
-            .union($.typeStatus.tag("shield").at($.id(:self.master.id))),
+            .union($.typeStatus.tag("shield").at(:self.master)),
         );
       };
       :e.increaseDamage(1);

--- a/packages/data/src/cards/event/other.gts
+++ b/packages/data/src/cards/event/other.gts
@@ -950,9 +950,7 @@ define card {
   addTarget $.my.character.has($.equipped.tag("weapon"));
   addTarget :(
     :queryAll(
-      $.my.character
-        .tagOf("weapon", $.id(:e.targets[0].id))
-        .exclude($.id(:e.targets[0].id)),
+      $.my.character.tagOf("weapon", :e.targets[0]).exclude(:e.targets[0]),
     ).map((c) => c.latest())
   );
   const weapon = :e.targets[0].hasWeapon()!;
@@ -981,9 +979,7 @@ define card {
   since "v3.3.0";
   addTarget $.my.character.has($.equipped.tag("artifact"));
   addTarget :(
-    :queryAll($.my.character.exclude($.id(:e.targets[0].id))).map((c) =>
-      c.latest(),
-    )
+    :queryAll($.my.character.exclude(:e.targets[0])).map((c) => c.latest())
   );
   const artifact = :e.targets[0].hasArtifact()!;
   artifact.resetUsagePerRound();

--- a/packages/data/src/characters/cryo/la_signora.gts
+++ b/packages/data/src/characters/cryo/la_signora.gts
@@ -148,7 +148,7 @@ define skill {
   cost DiceType.Energy, 2;
   :damage(DamageType.Cryo, 4);
   :heal(2, :self);
-  :dispose($.typeStatus.def(IcesealedCrimsonWitchOfEmbers).at($.id(:self.id)));
+  :dispose($.typeStatus.def(IcesealedCrimsonWitchOfEmbers).at(:self));
 };
 
 /**

--- a/packages/data/src/characters/cryo/qiqi.gts
+++ b/packages/data/src/characters/cryo/qiqi.gts
@@ -60,7 +60,8 @@ define combatStatus {
         return false;
       }
       return :query(
-        $.id(:e.skillCaller.id).intersection(
+        $.intersection(
+          :e.skillCaller,
           $.character.var("health", "<", "maxHealth"),
         ),
       );

--- a/packages/data/src/characters/dendro/jadeplume_terrorshroom.gts
+++ b/packages/data/src/characters/dendro/jadeplume_terrorshroom.gts
@@ -82,9 +82,9 @@ define skill {
   cost DiceType.Dendro, 3;
   cost DiceType.Energy, 2;
   const val =
-    :query(
-      $.typeStatus.def(RadicalVitalityStatus).at($.id(:self.id)),
-    )?.getVariable("vitality") ?? 0;
+    :query($.typeStatus.def(RadicalVitalityStatus).at(:self))?.getVariable(
+      "vitality",
+    ) ?? 0;
   :damage(DamageType.Dendro, 4 + val);
 };
 

--- a/packages/data/src/characters/dendro/kinich.gts
+++ b/packages/data/src/characters/dendro/kinich.gts
@@ -107,11 +107,7 @@ define status {
   since "v5.4.0";
   once beforeAction {
     when :( :self.master.isActive() );
-    :damage(
-      DamageType.Dendro,
-      3,
-      $.recentOppFrom($.character.id(:self.master.id)),
-    );
+    :damage(DamageType.Dendro, 3, $.recentOppFrom(:self.master));
   };
 };
 

--- a/packages/data/src/characters/electro/beidou.gts
+++ b/packages/data/src/characters/electro/beidou.gts
@@ -43,7 +43,7 @@ define skill {
   id 14054 as Wavestrider;
   skillType elemental;
   prepared;
-  :query($.typeStatus.def(TidecallerSurfEmbrace).at($.id(:self.id)))?.dispose();
+  :query($.typeStatus.def(TidecallerSurfEmbrace).at(:self))?.dispose();
   :damage(DamageType.Electro, 3);
   if (:self.hasEquipment(LightningStorm)) {
     :characterStatus(SummonerOfLightning, :self);

--- a/packages/data/src/characters/electro/ororon.gts
+++ b/packages/data/src/characters/electro/ororon.gts
@@ -208,7 +208,7 @@ define card {
       usage perRound, 1;
       :e.cancelCoreEffects();
       const characters = $[:e.where].character;
-      :damage(DamageType.Piercing, 2, characters.exclude($.id(:e.target.id)));
+      :damage(DamageType.Piercing, 2, characters.exclude(:e.target));
     };
   };
 };

--- a/packages/data/src/characters/electro/raiden_shogun.gts
+++ b/packages/data/src/characters/electro/raiden_shogun.gts
@@ -102,7 +102,7 @@ define skill {
   cost DiceType.Electro, 3;
   cost DiceType.Energy, 2;
   :damage(DamageType.Electro, 3);
-  :gainEnergy(2, $.my.character.exclude($.character.id(:self.id)));
+  :gainEnergy(2, $.my.character.exclude(:self));
 };
 
 /**

--- a/packages/data/src/characters/geo/yun_jin.gts
+++ b/packages/data/src/characters/geo/yun_jin.gts
@@ -36,9 +36,7 @@ define skill {
   id 16074 as SpearFlourish;
   skillType elemental;
   prepared;
-  :query(
-    $.typeStatus.def(ShieldOfSwirlingClouds).at($.id(:self.id)),
-  )?.dispose();
+  :query($.typeStatus.def(ShieldOfSwirlingClouds).at(:self))?.dispose();
   if (:self.getVariable("discardOrTuneCardCount") > 0) {
     :damage(DamageType.Geo, 3);
   } else {

--- a/packages/data/src/characters/hydro/candace.gts
+++ b/packages/data/src/characters/hydro/candace.gts
@@ -26,7 +26,7 @@ define skill {
   id 12074 as HeronStrike;
   skillType elemental;
   prepared;
-  :query($.typeStatus.def(HeronShield).at($.id(:self.id)))?.dispose();
+  :query($.typeStatus.def(HeronShield).at(:self))?.dispose();
   :damage(DamageType.Hydro, 3);
 };
 

--- a/packages/data/src/characters/pyro/amber.gts
+++ b/packages/data/src/characters/pyro/amber.gts
@@ -42,9 +42,11 @@ define summon {
   on useSkill {
     when :(
       :query(
-        $.id(:e.skillCaller.id)
-          .intersection($.character.def(Amber))
-          .intersection($.has($.equipped.def(BunnyTriggered))),
+        $.intersection(
+          :e.skillCaller,
+          $.character.def(Amber),
+          $.has($.equipped.def(BunnyTriggered)),
+        ),
       ) && :e.isSkillType("normal")
     );
     :damage(DamageType.Pyro, 4);

--- a/packages/data/src/characters/pyro/emperor_of_fire_and_iron.gts
+++ b/packages/data/src/characters/pyro/emperor_of_fire_and_iron.gts
@@ -28,9 +28,9 @@ define skill {
   prepared;
   :damage(DamageType.Piercing, 2, $.opp.standby);
   const value =
-    :query(
-      $.typeStatus.def(ArmoredCrabCarapace).at($.id(:self.id)),
-    )?.getVariable("shield") ?? 0;
+    :query($.typeStatus.def(ArmoredCrabCarapace).at(:self))?.getVariable(
+      "shield",
+    ) ?? 0;
   :damage(DamageType.Pyro, 1 + Math.floor(value / 2));
 };
 
@@ -93,9 +93,9 @@ define skill {
   skillType elemental;
   cost DiceType.Pyro, 3;
   const value =
-    :query(
-      $.typeStatus.def(ArmoredCrabCarapace).at($.id(:self.id)),
-    )?.getVariable("shield") ?? 0;
+    :query($.typeStatus.def(ArmoredCrabCarapace).at(:self))?.getVariable(
+      "shield",
+    ) ?? 0;
   if (value >= 7) {
     :damage(DamageType.Pyro, 2);
   } else {


### PR DESCRIPTION
## Summary
- make reactive states implement typed unordered queries backed by their entity id
- preserve existing direct-target behavior in SkillContext and fix the removedEntities area typing
- replace current card-data uses of `$.id(state.id)` with reactive states directly

## Tests
- `pnpm --filter @gi-tcg/core check`
- `pnpm --filter @gi-tcg/core test -- --run`
- `pnpm --filter @gi-tcg/core build`
- `pnpm --filter @gi-tcg/data check`
- `pnpm --filter @gi-tcg/data build`