### PR TITLE
feat(card-data-viewer): append technique and entities

### DIFF
--- a/packages/assets-manager/src/manager.ts
+++ b/packages/assets-manager/src/manager.ts
@@ -343,8 +343,10 @@ export class AssetsManager {
         description: "",
         hidden: false,
       };
-      if (!this.dataCacheSync.has(et.id)) {
-        this.dataCacheSync.set(et.id, data);
+      // May be registered by action_card. Merge.
+      const existing = this.dataCacheSync.get(et.id);
+      this.dataCacheSync.set(et.id, { ...existing, ...data });
+      if (!existing) {
         this.customDataNames.set(et.id, et.name);
         this.customDataImageUrls.set(et.id, et.cardFaceOrBuffIconUrl);
       }
@@ -637,4 +639,6 @@ export class AssetsManager {
   }
 }
 
-export const DEFAULT_ASSETS_MANAGER = new AssetsManager({ defaultDeckCompatible: true });
+export const DEFAULT_ASSETS_MANAGER = new AssetsManager({
+  defaultDeckCompatible: true,
+});

--- a/packages/card-data-viewer/src/CardDataViewer.tsx
+++ b/packages/card-data-viewer/src/CardDataViewer.tsx
@@ -55,6 +55,7 @@ export type ViewerInput =
 export interface CardDataViewerProps {
   inputs: ViewerInput[];
   mainImageDefId: number | null;
+  inlineSubEntities: boolean;
 }
 
 export interface CardDataViewerContainerProps extends CardDataViewerProps {
@@ -116,6 +117,41 @@ function CardDataViewer(props: CardDataViewerProps) {
     setExplainKeyword((prev) => (prev === definitionId ? null : definitionId));
   };
 
+  const SubEntityList = () => (
+    <div class="flex flex-col gap-[0.5em] not-first:mt-[0.5em]">
+      <For each={subEntities()}>
+        {(entity) => (
+          <Switch>
+            <Match when={typeof entity === "string" && entity}>
+              {(entityType) => (
+                <h3
+                  class="w-full text-center rounded-full entity-category"
+                  bool:data-show-combine-button={showCombineButton(
+                    entityType(),
+                  )}
+                  onClick={() => {
+                    if (showCombineButton(entityType())) {
+                      setCombineCharEntities((v) => !v);
+                    }
+                  }}
+                >
+                  {t(entityType())}
+                </h3>
+              )}
+            </Match>
+            <Match when={true}>
+              <Entity
+                input={entity as ViewerInput}
+                asChild
+                onRequestExplain={onRequestExplain}
+              />
+            </Match>
+          </Switch>
+        )}
+      </For>
+    </div>
+  );
+
   return (
     <div class="gi-tcg-card-data-viewer reset">
       <ErrorBoundary
@@ -152,43 +188,15 @@ function CardDataViewer(props: CardDataViewerProps) {
           {(input) => (
             <div class="card-panel">
               <Skill input={input} onRequestExplain={onRequestExplain} />
+              <Show when={props.inlineSubEntities && subEntities().length}>
+                <SubEntityList />
+              </Show>
             </div>
           )}
         </For>
-        <Show when={subEntities()?.length}>
+        <Show when={!props.inlineSubEntities && subEntities().length}>
           <div class="card-panel">
-            <div class="flex flex-col gap-[0.5em]">
-              <For each={subEntities()}>
-                {(entity) => (
-                  <Switch>
-                    <Match when={typeof entity === "string" && entity}>
-                      {(entityType) => (
-                        <h3
-                          class="w-full text-center rounded-full entity-category"
-                          bool:data-show-combine-button={showCombineButton(
-                            entityType(),
-                          )}
-                          onClick={() => {
-                            if (showCombineButton(entityType())) {
-                              setCombineCharEntities((v) => !v);
-                            }
-                          }}
-                        >
-                          {t(entityType())}
-                        </h3>
-                      )}
-                    </Match>
-                    <Match when={true}>
-                      <Entity
-                        input={entity as ViewerInput}
-                        asChild
-                        onRequestExplain={onRequestExplain}
-                      />
-                    </Match>
-                  </Switch>
-                )}
-              </For>
-            </div>
+            <SubEntityList />
           </div>
         </Show>
         <Show when={explainKeyword()}>

--- a/packages/card-data-viewer/src/CardDataViewer.tsx
+++ b/packages/card-data-viewer/src/CardDataViewer.tsx
@@ -32,7 +32,7 @@ import { ActionCard, Character, Entity, Keyword, Skill } from "./Entity";
 import { useAssetsManager } from "./context";
 import { CardFace } from "./CardFace";
 
-type MainStateType = "character" | "card" | "entity" | "skill" | "keyword";
+type MainStateType = "character" | "card" | "entity" | "keyword";
 type SubStateType =
   "equipment" | "status" | "equipAndStatus" | "combatStatus" | "attachment";
 
@@ -42,7 +42,7 @@ export type ViewerInput =
   | {
       from: "definitionId";
       definitionId: number;
-      type: StateType;
+      type: StateType | "skill";
     }
   | {
       from: "state";
@@ -55,7 +55,6 @@ export type ViewerInput =
 export interface CardDataViewerProps {
   inputs: ViewerInput[];
   mainImageDefId: number | null;
-  inlineSubEntities: boolean;
 }
 
 export interface CardDataViewerContainerProps extends CardDataViewerProps {
@@ -88,23 +87,26 @@ function CardDataViewer(props: CardDataViewerProps) {
       }
     });
   });
-  const subEntities = () => {
+  const subEntities = createMemo(() => {
     const render: (ViewerInput | SubStateType)[] = [];
     const g = grouped();
     for (const t of [
+      "skill",
       "equipment",
       "status",
       "equipAndStatus",
       "combatStatus",
       "attachment",
-    ] as SubStateType[]) {
+    ] as const) {
       if (g[t]?.length) {
-        render.push(t);
+        if (t !== "skill") {
+          render.push(t);
+        }
         render.push(...g[t]);
       }
     }
     return render;
-  };
+  });
 
   const showCombineButton = (type: SubStateType) =>
     !!(
@@ -116,41 +118,6 @@ function CardDataViewer(props: CardDataViewerProps) {
   const onRequestExplain = (definitionId: number | null) => {
     setExplainKeyword((prev) => (prev === definitionId ? null : definitionId));
   };
-
-  const SubEntityList = () => (
-    <div class="flex flex-col gap-[0.5em] not-first:mt-[0.5em]">
-      <For each={subEntities()}>
-        {(entity) => (
-          <Switch>
-            <Match when={typeof entity === "string" && entity}>
-              {(entityType) => (
-                <h3
-                  class="w-full text-center rounded-full entity-category"
-                  bool:data-show-combine-button={showCombineButton(
-                    entityType(),
-                  )}
-                  onClick={() => {
-                    if (showCombineButton(entityType())) {
-                      setCombineCharEntities((v) => !v);
-                    }
-                  }}
-                >
-                  {t(entityType())}
-                </h3>
-              )}
-            </Match>
-            <Match when={true}>
-              <Entity
-                input={entity as ViewerInput}
-                asChild
-                onRequestExplain={onRequestExplain}
-              />
-            </Match>
-          </Switch>
-        )}
-      </For>
-    </div>
-  );
 
   return (
     <div class="gi-tcg-card-data-viewer reset">
@@ -184,19 +151,46 @@ function CardDataViewer(props: CardDataViewerProps) {
             </div>
           )}
         </For>
-        <For each={grouped().skill}>
-          {(input) => (
-            <div class="card-panel">
-              <Skill input={input} onRequestExplain={onRequestExplain} />
-              <Show when={props.inlineSubEntities && subEntities().length}>
-                <SubEntityList />
-              </Show>
-            </div>
-          )}
-        </For>
-        <Show when={!props.inlineSubEntities && subEntities().length}>
+        <Show when={subEntities().length}>
           <div class="card-panel">
-            <SubEntityList />
+            <div class="flex flex-col gap-[0.5em]">
+              <For each={subEntities()}>
+                {(entity) => (
+                  <Switch>
+                    <Match when={typeof entity === "string" && entity}>
+                      {(entityType) => (
+                        <h3
+                          class="w-full text-center rounded-full entity-category"
+                          bool:data-show-combine-button={showCombineButton(
+                            entityType(),
+                          )}
+                          onClick={() => {
+                            if (showCombineButton(entityType())) {
+                              setCombineCharEntities((v) => !v);
+                            }
+                          }}
+                        >
+                          {t(entityType())}
+                        </h3>
+                      )}
+                    </Match>
+                    <Match when={(entity as ViewerInput).type === "skill"}>
+                      <Skill
+                        input={entity as ViewerInput}
+                        onRequestExplain={onRequestExplain}
+                      />
+                    </Match>
+                    <Match when={true}>
+                      <Entity
+                        input={entity as ViewerInput}
+                        asChild
+                        onRequestExplain={onRequestExplain}
+                      />
+                    </Match>
+                  </Switch>
+                )}
+              </For>
+            </div>
           </div>
         </Show>
         <Show when={explainKeyword()}>

--- a/packages/card-data-viewer/src/Entity.tsx
+++ b/packages/card-data-viewer/src/Entity.tsx
@@ -71,11 +71,8 @@ export function Character(props: CardDataProps) {
       Promise.all(
         definitionIds.map((definitionId) =>
           (manager.getData(definitionId) as Promise<EntityRawData>)
-            .then(
-              (data) =>
-                data.skills.filter(
-                  (sk) => sk.type === "GCG_SKILL_TAG_VEHICLE",
-                ) ?? [],
+            .then((data) =>
+              data.skills.filter((sk) => sk.type === "GCG_SKILL_TAG_VEHICLE"),
             )
             .catch(() => []),
         ),

--- a/packages/card-data-viewer/src/Entity.tsx
+++ b/packages/card-data-viewer/src/Entity.tsx
@@ -65,29 +65,25 @@ export function Character(props: CardDataProps) {
         ?.entity.filter((entity) => typeof entity.equipment === "number")
         .map((entity) => entity.definitionId) ?? [],
   );
-  const [equipmentData] = createResource(
-    () => {
-      const definitionIds = equipmentDefinitionIds();
-      return definitionIds.length
-        ? ([definitionIds, assetsManager()] as const)
-        : undefined;
-    },
+  const [techniqueData] = createResource(
+    () => [equipmentDefinitionIds(), assetsManager()] as const,
     ([definitionIds, manager]) =>
       Promise.all(
-        definitionIds.map(
-          (definitionId) =>
-            manager.getData(definitionId) as Promise<EntityRawData>,
+        definitionIds.map((definitionId) =>
+          (manager.getData(definitionId) as Promise<EntityRawData>)
+            .then(
+              (data) =>
+                data.skills.filter(
+                  (sk) => sk.type === "GCG_SKILL_TAG_VEHICLE",
+                ) ?? [],
+            )
+            .catch(() => []),
         ),
       ),
   );
   const skills = createMemo(() => [
     ...(data()?.skills ?? []),
-    ...(equipmentData()?.flatMap((equipment) =>
-      (equipment.skills ?? []).filter(
-        (skill) =>
-          skill.type === "GCG_SKILL_TAG_VEHICLE" && !skill.hidden,
-      ),
-    ) ?? []),
+    ...(techniqueData()?.flat() ?? []),
   ]);
   const hpText = createMemo(() => {
     const st = state();

--- a/packages/card-data-viewer/src/Entity.tsx
+++ b/packages/card-data-viewer/src/Entity.tsx
@@ -59,6 +59,36 @@ export function Character(props: CardDataProps) {
     () => [props.input.definitionId, assetsManager()] as const,
     ([defId, manager]) => manager.getData(defId) as Promise<CharacterRawData>,
   );
+  const equipmentDefinitionIds = createMemo(
+    () =>
+      state()
+        ?.entity.filter((entity) => typeof entity.equipment === "number")
+        .map((entity) => entity.definitionId) ?? [],
+  );
+  const [equipmentData] = createResource(
+    () => {
+      const definitionIds = equipmentDefinitionIds();
+      return definitionIds.length
+        ? ([definitionIds, assetsManager()] as const)
+        : undefined;
+    },
+    ([definitionIds, manager]) =>
+      Promise.all(
+        definitionIds.map(
+          (definitionId) =>
+            manager.getData(definitionId) as Promise<EntityRawData>,
+        ),
+      ),
+  );
+  const skills = createMemo(() => [
+    ...(data()?.skills ?? []),
+    ...(equipmentData()?.flatMap((equipment) =>
+      (equipment.skills ?? []).filter(
+        (skill) =>
+          skill.type === "GCG_SKILL_TAG_VEHICLE" && !skill.hidden,
+      ),
+    ) ?? []),
+  ]);
   const hpText = createMemo(() => {
     const st = state();
     if (st) {
@@ -92,7 +122,7 @@ export function Character(props: CardDataProps) {
               </dl>
               <Tags tags={data().tags} />
               <ul class="flex flex-col gap-[0.5em]">
-                <For each={data().skills}>
+                <For each={skills()}>
                   {(skill) => (
                     <Show when={!skill.hidden}>
                       <Skill

--- a/packages/card-data-viewer/src/dev.tsx
+++ b/packages/card-data-viewer/src/dev.tsx
@@ -26,50 +26,41 @@ function App() {
       locale: () => "zh-CN"
     });
   onMount(() => {
-    showState(
-      "character",
-      {
-        id: -500001,
-        definitionId: 1212,
-        aura: 0,
-        defeated: false,
-        health: 5,
-        maxHealth: 100,
-        energy: 2,
-        maxEnergy: 2,
-        tags: 0,
-        entity: [
-          {
-            id: -500002,
-            definitionId: 312015,
-            hasUsagePerRound: false,
-            variableName: "usage",
-            variableValue: 3,
-            equipment: 1,
-            definitionCost: [],
-            tags: 0,
-            type: 2,
-            descriptionDictionary: {
-              "[GCG_TOKEN_SHIELD]": "1",
-            },
-            attachment: [],
+    const skillId = Number(
+      new URLSearchParams(location.search).get("skill") ?? 12121,
+    );
+    showSkill(skillId, {
+      characterEntities: [
+        {
+          id: -500002,
+          definitionId: 312015,
+          hasUsagePerRound: false,
+          variableName: "usage",
+          variableValue: 3,
+          equipment: 1,
+          definitionCost: [],
+          tags: 0,
+          type: 2,
+          descriptionDictionary: {
+            "[GCG_TOKEN_SHIELD]": "1",
           },
-          {
-            id: -500004,
-            definitionId: 313001,
-            hasUsagePerRound: false,
-            variableName: "usage",
-            variableValue: 2,
-            equipment: 3,
-            definitionCost: [],
-            tags: 0,
-            type: 6,
-            descriptionDictionary: {},
-            attachment: [],
-          },
-        ],
-      },
-      [
+          attachment: [],
+        },
+        {
+          id: -500004,
+          definitionId: 313001,
+          hasUsagePerRound: false,
+          variableName: "usage",
+          variableValue: 2,
+          equipment: 3,
+          definitionCost: [],
+          tags: 0,
+          type: 6,
+          descriptionDictionary: {},
+          attachment: [],
+        },
+      ],
+      combatStatuses: [
         {
           id: -500003,
           definitionId: 111,
@@ -83,7 +74,7 @@ function App() {
           attachment: [],
         },
       ],
-    );
+    });
     // showState("card", {
     //   id: -5000001,
     //   definitionId: 330005,

--- a/packages/card-data-viewer/src/dev.tsx
+++ b/packages/card-data-viewer/src/dev.tsx
@@ -20,47 +20,56 @@ import { AssetsManager } from "@gi-tcg/assets-manager";
 
 function App() {
   const enAssetsManager = new AssetsManager({ language: "CHS" });
-  const { CardDataViewer, showCharacter, showState, showCard, showSkill } =
+  const { CardDataViewer, showCharacter, showState, showCard } =
     createCardDataViewer({
       assetsManager: () => enAssetsManager,
-      locale: () => "zh-CN"
+      locale: () => "zh-CN",
     });
   onMount(() => {
-    const skillId = Number(
-      new URLSearchParams(location.search).get("skill") ?? 12121,
-    );
-    showSkill(skillId, {
-      characterEntities: [
-        {
-          id: -500002,
-          definitionId: 312015,
-          hasUsagePerRound: false,
-          variableName: "usage",
-          variableValue: 3,
-          equipment: 1,
-          definitionCost: [],
-          tags: 0,
-          type: 2,
-          descriptionDictionary: {
-            "[GCG_TOKEN_SHIELD]": "1",
+    showState(
+      "character",
+      {
+        id: -500001,
+        definitionId: 1212,
+        aura: 0,
+        defeated: false,
+        health: 5,
+        maxHealth: 21,
+        energy: 2,
+        maxEnergy: 2,
+        tags: 0,
+        entity: [
+          {
+            id: -500002,
+            definitionId: 312015,
+            hasUsagePerRound: false,
+            variableName: "usage",
+            variableValue: 3,
+            equipment: 1,
+            definitionCost: [],
+            tags: 0,
+            type: 2,
+            descriptionDictionary: {
+              "[GCG_TOKEN_SHIELD]": "1",
+            },
+            attachment: [],
           },
-          attachment: [],
-        },
-        {
-          id: -500004,
-          definitionId: 313001,
-          hasUsagePerRound: false,
-          variableName: "usage",
-          variableValue: 2,
-          equipment: 3,
-          definitionCost: [],
-          tags: 0,
-          type: 6,
-          descriptionDictionary: {},
-          attachment: [],
-        },
-      ],
-      combatStatuses: [
+          {
+            id: -500004,
+            definitionId: 313001,
+            hasUsagePerRound: false,
+            variableName: "usage",
+            variableValue: 2,
+            equipment: 3,
+            definitionCost: [],
+            tags: 0,
+            type: 6,
+            descriptionDictionary: {},
+            attachment: [],
+          },
+        ],
+      },
+      [
         {
           id: -500003,
           definitionId: 111,
@@ -74,7 +83,10 @@ function App() {
           attachment: [],
         },
       ],
-    });
+      {
+        // skillOnly: 12111,
+      },
+    );
     // showState("card", {
     //   id: -5000001,
     //   definitionId: 330005,

--- a/packages/card-data-viewer/src/dev.tsx
+++ b/packages/card-data-viewer/src/dev.tsx
@@ -54,6 +54,19 @@ function App() {
             },
             attachment: [],
           },
+          {
+            id: -500004,
+            definitionId: 313001,
+            hasUsagePerRound: false,
+            variableName: "usage",
+            variableValue: 2,
+            equipment: 3,
+            definitionCost: [],
+            tags: 0,
+            type: 6,
+            descriptionDictionary: {},
+            attachment: [],
+          },
         ],
       },
       [
@@ -91,18 +104,18 @@ function App() {
     //     },
     //   ],
     // });
-    showState("entity", {
-      id: -5000001,
-      definitionId: 113041,
-      definitionCost: [],
-      tags: 0,
-      descriptionDictionary: {},
-      hasUsagePerRound: false,
-      variableName: "usage",
-      variableValue: 2,
-      type: 4,
-      attachment: []
-    });
+    // showState("entity", {
+    //   id: -5000001,
+    //   definitionId: 113041,
+    //   definitionCost: [],
+    //   tags: 0,
+    //   descriptionDictionary: {},
+    //   hasUsagePerRound: false,
+    //   variableName: "usage",
+    //   variableValue: 2,
+    //   type: 4,
+    //   attachment: [],
+    // });
     // showCard(212111);
     // showCharacter(1610);
     // showSkill(12111);

--- a/packages/card-data-viewer/src/index.tsx
+++ b/packages/card-data-viewer/src/index.tsx
@@ -39,14 +39,13 @@ import { translator } from "@solid-primitives/i18n";
 export interface RegisterResult {
   readonly CardDataViewer: () => JSX.Element;
   readonly showCharacter: (id: number, opt?: ShowCardDataViewerOption) => void;
-  readonly showSkill: (id: number, opt?: ShowSkillDataViewerOption) => void;
   readonly showCard: (id: number, opt?: ShowCardDataViewerOption) => void;
   readonly showState: {
     (
       type: "character",
       state: PbCharacterState,
       combatStatuses: PbEntityState[],
-      opt?: ShowCardDataViewerOption,
+      opt?: ShowCharacterStateOption,
     ): void;
     /**
      * - Pass in type = "entity" for on-stage entities (which reads `rawPlayingDescription`)
@@ -71,9 +70,8 @@ export interface ShowCardDataViewerOption {
   includesImage?: boolean;
 }
 
-export interface ShowSkillDataViewerOption extends ShowCardDataViewerOption {
-  characterEntities?: PbEntityState[];
-  combatStatuses?: PbEntityState[];
+export interface ShowCharacterStateOption extends ShowCardDataViewerOption {
+  skillOnly?: number;
 }
 
 export function createCardDataViewer(
@@ -88,7 +86,6 @@ export function createCardDataViewer(
   const [shown, setShown] = createSignal(false);
   const [mainImageDefId, setMainImageDefId] = createSignal<number | null>(null);
   const [inputs, setInputs] = createSignal<ViewerInput[]>([]);
-  const [inlineSubEntities, setInlineSubEntities] = createSignal(false);
 
   const showDef = (
     definitionId: number,
@@ -96,7 +93,6 @@ export function createCardDataViewer(
     opt?: ShowCardDataViewerOption,
   ) => {
     setMainImageDefId(opt?.includesImage ? definitionId : null);
-    setInlineSubEntities(false);
     setInputs([
       {
         from: "definitionId",
@@ -131,7 +127,6 @@ export function createCardDataViewer(
           shown={shown()}
           inputs={inputs()}
           mainImageDefId={mainImageDefId()}
-          inlineSubEntities={inlineSubEntities()}
         />
       </AssetsContext.Provider>
     ),
@@ -141,48 +136,38 @@ export function createCardDataViewer(
     showCharacter: (id: number, opt?: ShowCardDataViewerOption) => {
       showDef(id, "character", opt);
     },
-    showSkill: (id: number, opt?: ShowSkillDataViewerOption) => {
-      const characterEntities = opt?.characterEntities ?? [];
-      const combatStatuses = opt?.combatStatuses ?? [];
-      setMainImageDefId(opt?.includesImage ? id : null);
-      setInlineSubEntities(
-        !!(opt?.characterEntities || opt?.combatStatuses),
-      );
-      setInputs([
-        {
-          from: "definitionId",
-          definitionId: id,
-          type: "skill",
-        },
-        ...characterEntities.map((st) =>
-          mapStateToInput(
-            st,
-            typeof st.equipment === "number" ? "equipment" : "status",
-          ),
-        ),
-        ...combatStatuses.map((st) => mapStateToInput(st, "combatStatus")),
-      ]);
-      setShown(true);
-    },
     showState: (
       type: StateType,
       state: PbCharacterState | PbEntityState,
       combatStatusesOrOpt?: PbEntityState[] | ShowCardDataViewerOption,
-      opt?: ShowCardDataViewerOption,
+      opt?: ShowCharacterStateOption,
     ) => {
       const extra =
         type === "character" ? (combatStatusesOrOpt as PbEntityState[]) : [];
       const options =
         type === "character"
-          ? opt
-          : (combatStatusesOrOpt as ShowCardDataViewerOption | undefined);
+          ? (opt as ShowCharacterStateOption | undefined)
+          : (combatStatusesOrOpt as ShowCharacterStateOption | undefined);
       setMainImageDefId(
-        options?.includesImage === false ? null : state.definitionId,
+        options?.includesImage === false ||
+          typeof options?.skillOnly === "number"
+          ? null
+          : state.definitionId,
       );
-      setInlineSubEntities(false);
+      let mainItem = mapStateToInput(state, type);
+      if (
+        mainItem.type === "character" &&
+        typeof options?.skillOnly === "number"
+      ) {
+        mainItem = {
+          from: "definitionId",
+          type: "skill",
+          definitionId: options.skillOnly,
+        };
+      }
       setInputs([
         // main item
-        mapStateToInput(state, type),
+        mainItem,
         // character zone entities
         ...("entity" in state
           ? state.entity.map((st) =>

--- a/packages/card-data-viewer/src/index.tsx
+++ b/packages/card-data-viewer/src/index.tsx
@@ -39,7 +39,7 @@ import { translator } from "@solid-primitives/i18n";
 export interface RegisterResult {
   readonly CardDataViewer: () => JSX.Element;
   readonly showCharacter: (id: number, opt?: ShowCardDataViewerOption) => void;
-  readonly showSkill: (id: number, opt?: ShowCardDataViewerOption) => void;
+  readonly showSkill: (id: number, opt?: ShowSkillDataViewerOption) => void;
   readonly showCard: (id: number, opt?: ShowCardDataViewerOption) => void;
   readonly showState: {
     (
@@ -71,6 +71,11 @@ export interface ShowCardDataViewerOption {
   includesImage?: boolean;
 }
 
+export interface ShowSkillDataViewerOption extends ShowCardDataViewerOption {
+  characterEntities?: PbEntityState[];
+  combatStatuses?: PbEntityState[];
+}
+
 export function createCardDataViewer(
   option: CreateCardDataViewerOption = {},
 ): RegisterResult {
@@ -83,6 +88,7 @@ export function createCardDataViewer(
   const [shown, setShown] = createSignal(false);
   const [mainImageDefId, setMainImageDefId] = createSignal<number | null>(null);
   const [inputs, setInputs] = createSignal<ViewerInput[]>([]);
+  const [inlineSubEntities, setInlineSubEntities] = createSignal(false);
 
   const showDef = (
     definitionId: number,
@@ -90,6 +96,7 @@ export function createCardDataViewer(
     opt?: ShowCardDataViewerOption,
   ) => {
     setMainImageDefId(opt?.includesImage ? definitionId : null);
+    setInlineSubEntities(false);
     setInputs([
       {
         from: "definitionId",
@@ -124,6 +131,7 @@ export function createCardDataViewer(
           shown={shown()}
           inputs={inputs()}
           mainImageDefId={mainImageDefId()}
+          inlineSubEntities={inlineSubEntities()}
         />
       </AssetsContext.Provider>
     ),
@@ -133,8 +141,28 @@ export function createCardDataViewer(
     showCharacter: (id: number, opt?: ShowCardDataViewerOption) => {
       showDef(id, "character", opt);
     },
-    showSkill: (id: number, opt?: ShowCardDataViewerOption) => {
-      showDef(id, "skill", opt);
+    showSkill: (id: number, opt?: ShowSkillDataViewerOption) => {
+      const characterEntities = opt?.characterEntities ?? [];
+      const combatStatuses = opt?.combatStatuses ?? [];
+      setMainImageDefId(opt?.includesImage ? id : null);
+      setInlineSubEntities(
+        !!(opt?.characterEntities || opt?.combatStatuses),
+      );
+      setInputs([
+        {
+          from: "definitionId",
+          definitionId: id,
+          type: "skill",
+        },
+        ...characterEntities.map((st) =>
+          mapStateToInput(
+            st,
+            typeof st.equipment === "number" ? "equipment" : "status",
+          ),
+        ),
+        ...combatStatuses.map((st) => mapStateToInput(st, "combatStatus")),
+      ]);
+      setShown(true);
     },
     showState: (
       type: StateType,
@@ -151,6 +179,7 @@ export function createCardDataViewer(
       setMainImageDefId(
         options?.includesImage === false ? null : state.definitionId,
       );
+      setInlineSubEntities(false);
       setInputs([
         // main item
         mapStateToInput(state, type),

--- a/packages/web-ui-core/src/components/Chessboard.tsx
+++ b/packages/web-ui-core/src/components/Chessboard.tsx
@@ -1021,7 +1021,7 @@ type SelectingItem = (
     }
   | {
       type: "skill";
-      info: SkillInfo & { id: number };
+      info: SkillInfo & { id: number; who: 0 | 1; characterId?: number };
     }
   | {
       type: "externalCard";
@@ -1106,7 +1106,18 @@ export function Chessboard(props: ChessboardProps) {
     } else if (item.type === "entity") {
       dataViewerController.showState("entity", item.info.data);
     } else if (item.type === "skill") {
-      dataViewerController.showSkill(item.info.id);
+      const player = localProps.data.state.player[item.info.who];
+      const character = player.character.find(
+        (character) => character.id === item.info.characterId,
+      );
+      if (item.info.isTechnique || !character) {
+        dataViewerController.showSkill(item.info.id);
+      } else {
+        dataViewerController.showSkill(item.info.id, {
+          characterEntities: character.entity,
+          combatStatuses: player.combatStatus,
+        });
+      }
     } else if (item.type === "externalCard") {
       if (typeof item.info === "number") {
         dataViewerController.showCard(item.info, {
@@ -1749,7 +1760,16 @@ export function Chessboard(props: ChessboardProps) {
         localProps.onStepActionState?.(step, selectedDiceValue());
       }
     } else {
-      setSelectingItem({ type: "skill", info: { ...sk, id: sk.id } });
+      setSelectingItem({
+        type: "skill",
+        info: {
+          ...sk,
+          id: sk.id,
+          who: localProps.who,
+          characterId:
+            localProps.data.state.player[localProps.who].activeCharacterId,
+        },
+      });
       const step = localProps.actionState?.availableSteps.find(
         (s) => s.type === "clickSkillButton" && s.skillId === sk.id,
       );
@@ -1763,7 +1783,13 @@ export function Chessboard(props: ChessboardProps) {
     setShowDeclareEndButton(false);
     setSelectingItem({
       type: "skill",
-      info: { ...sk, id: sk.id as number },
+      info: {
+        ...sk,
+        id: sk.id as number,
+        who: flip(localProps.who),
+        characterId:
+          localProps.data.state.player[flip(localProps.who)].activeCharacterId,
+      },
     });
     setFocusingHands(false);
     setShowCardHint("myHand", null);

--- a/packages/web-ui-core/src/components/Chessboard.tsx
+++ b/packages/web-ui-core/src/components/Chessboard.tsx
@@ -1021,7 +1021,8 @@ type SelectingItem = (
     }
   | {
       type: "skill";
-      info: SkillInfo & { id: number; who: 0 | 1; characterId?: number };
+      character: CharacterInfo;
+      info: { id: number };
     }
   | {
       type: "externalCard";
@@ -1106,18 +1107,12 @@ export function Chessboard(props: ChessboardProps) {
     } else if (item.type === "entity") {
       dataViewerController.showState("entity", item.info.data);
     } else if (item.type === "skill") {
-      const player = localProps.data.state.player[item.info.who];
-      const character = player.character.find(
-        (character) => character.id === item.info.characterId,
+      dataViewerController.showState(
+        "character",
+        item.character.data,
+        item.character.combatStatus.map((x) => x.data),
+        { skillOnly: item.info.id },
       );
-      if (item.info.isTechnique || !character) {
-        dataViewerController.showSkill(item.info.id);
-      } else {
-        dataViewerController.showSkill(item.info.id, {
-          characterEntities: character.entity,
-          combatStatuses: player.combatStatus,
-        });
-      }
     } else if (item.type === "externalCard") {
       if (typeof item.info === "number") {
         dataViewerController.showCard(item.info, {
@@ -1391,14 +1386,8 @@ export function Chessboard(props: ChessboardProps) {
   };
   const isTechnique = (id: SkillInfo["id"]): boolean =>
     typeof id === "number" && id.toString().length > 5;
-  const activeEnergy = (who: 0 | 1) => {
-    const player = localProps.data.state.player[who];
-    const { energy = 0, maxEnergy = 1 } =
-      player.character.find((ch) => ch.id === player.activeCharacterId) ?? {};
-    return { energy, maxEnergy };
-  };
   const energyPercentage = (who: 0 | 1): number => {
-    const { energy, maxEnergy } = activeEnergy(who);
+    const { energy = 0, maxEnergy = 1 } = activeCharacter(who)?.data ?? {};
     return Math.min(energy / maxEnergy, 1);
   };
   const mySkills = createMemo<SkillInfo[]>(() => {
@@ -1752,6 +1741,13 @@ export function Chessboard(props: ChessboardProps) {
     }
   };
 
+  const activeCharacter = (who: 0 | 1) => {
+    const player = localProps.data.state.player[who];
+    return children().characters.find(
+      (char) => char.id === player.activeCharacterId,
+    );
+  };
+
   const onSkillClick = (sk: SkillInfo) => {
     setShowDeclareEndButton(false);
     if (sk.id === "switchActive") {
@@ -1760,16 +1756,16 @@ export function Chessboard(props: ChessboardProps) {
         localProps.onStepActionState?.(step, selectedDiceValue());
       }
     } else {
-      setSelectingItem({
-        type: "skill",
-        info: {
-          ...sk,
-          id: sk.id,
-          who: localProps.who,
-          characterId:
-            localProps.data.state.player[localProps.who].activeCharacterId,
-        },
-      });
+      const character = activeCharacter(localProps.who);
+      if (character) {
+        setSelectingItem({
+          type: "skill",
+          character,
+          info: {
+            id: sk.id,
+          },
+        });
+      }
       const step = localProps.actionState?.availableSteps.find(
         (s) => s.type === "clickSkillButton" && s.skillId === sk.id,
       );
@@ -1781,16 +1777,16 @@ export function Chessboard(props: ChessboardProps) {
 
   const onOppSkillClick = (sk: SkillInfo) => {
     setShowDeclareEndButton(false);
-    setSelectingItem({
-      type: "skill",
-      info: {
-        ...sk,
-        id: sk.id as number,
-        who: flip(localProps.who),
-        characterId:
-          localProps.data.state.player[flip(localProps.who)].activeCharacterId,
-      },
-    });
+    const character = activeCharacter(flip(localProps.who));
+    if (character && typeof sk.id === "number") {
+      setSelectingItem({
+        type: "skill",
+        character,
+        info: {
+          id: sk.id,
+        },
+      });
+    }
     setFocusingHands(false);
     setShowCardHint("myHand", null);
   };

--- a/packages/web-ui-core/src/components/Chessboard.tsx
+++ b/packages/web-ui-core/src/components/Chessboard.tsx
@@ -1386,6 +1386,12 @@ export function Chessboard(props: ChessboardProps) {
   };
   const isTechnique = (id: SkillInfo["id"]): boolean =>
     typeof id === "number" && id.toString().length > 5;
+  const activeCharacter = (who: 0 | 1) => {
+    const player = localProps.data.state.player[who];
+    return children().characters.find(
+      (char) => char.id === player.activeCharacterId,
+    );
+  };
   const energyPercentage = (who: 0 | 1): number => {
     const { energy = 0, maxEnergy = 1 } = activeCharacter(who)?.data ?? {};
     return Math.min(energy / maxEnergy, 1);
@@ -1739,13 +1745,6 @@ export function Chessboard(props: ChessboardProps) {
     if (entityInfo.clickStep) {
       localProps.onStepActionState?.(entityInfo.clickStep, selectedDiceValue());
     }
-  };
-
-  const activeCharacter = (who: 0 | 1) => {
-    const player = localProps.data.state.player[who];
-    return children().characters.find(
-      (char) => char.id === player.activeCharacterId,
-    );
   };
 
   const onSkillClick = (sk: SkillInfo) => {


### PR DESCRIPTION
Fixes #960.

1. Append `techniques` to `showCharacter`.
2. Refactor `showSkill` as a special case of `showState`, so that active character's status & combat statuses are shown in same panel.