### PR TITLE
fix(core): onPlayCard Event should get cardState before cleaning attachment

### DIFF
--- a/packages/core/src/base/skill.ts
+++ b/packages/core/src/base/skill.ts
@@ -229,7 +229,9 @@ export class SkillContextOptions {
     result.associatedExtensionId = extId;
     return result;
   }
-  static plain: Immutable<SkillContextOptions> = freeze(new SkillContextOptions());
+  static plain: Immutable<SkillContextOptions> = freeze(
+    new SkillContextOptions(),
+  );
 }
 
 export interface DamageInfo {
@@ -755,9 +757,12 @@ export class ModifyUseSkillEventArg extends UseSkillEventArg {
 export class PlayCardEventArg extends PlayerEventArg {
   constructor(
     state: GameState,
-    public readonly playCardInfo: PlayCardInfo,
+    public readonly playCardInfo: Extract<ActionInfo, PlayCardInfo>,
   ) {
     super(state, playCardInfo.who);
+  }
+  playCost() {
+    return diceCostSize(this.playCardInfo.cost);
   }
   get card() {
     return this.playCardInfo.skill.caller;

--- a/packages/core/src/skill_executor.ts
+++ b/packages/core/src/skill_executor.ts
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import {
+  type ActionInfo,
   type CoreSkillResult,
   defineSkillInfo,
   DisposeEventArg,
@@ -39,7 +40,11 @@ import {
   type EntityState,
   stringifyState,
 } from "./base/state";
-import { PbSkillType, type ExposedMutation } from "@gi-tcg/typings";
+import {
+  ActionValidity,
+  PbSkillType,
+  type ExposedMutation,
+} from "@gi-tcg/typings";
 import {
   allSkills,
   applyAttachmentModifications,
@@ -496,16 +501,18 @@ export class SkillExecutor {
           );
           continue;
         }
-        const { willBeEffectless } = applyAttachmentModifications(
-          this.state,
-          arg.card,
-        );
-        const playCardInfo: PlayCardInfo = {
+        const { shouldFast, requiredCost, willBeEffectless } =
+          applyAttachmentModifications(this.state, arg.card);
+        const playCardInfo: Extract<ActionInfo, PlayCardInfo> = {
           type: "playCard",
           who: arg.who,
           skill: skillInfo,
           targets: targets.targets,
           willBeEffectless,
+          cost: requiredCost,
+          fast: shouldFast,
+          autoSelectedDice: [],
+          validity: ActionValidity.VALID,
         };
         if (!arg.requestOption.viaSelect) {
           await this.handleEvent([

--- a/packages/data/src/cards/event/other.gts
+++ b/packages/data/src/cards/event/other.gts
@@ -2794,6 +2794,7 @@ define combatStatus {
         state: ch.latest(),
         varName: "health",
         value: 5,
+        oldValue: 0,
         direction: ch.health > 5 ? "decrease" : "increase",
       });
     }
@@ -2991,7 +2992,7 @@ define card {
 define combatStatus {
   id 303248 as ThePowerOfResearchInEffect;
   on playCard {
-    when :( :e.card.diceCost() >= 3 );
+    when :( :e.playCost() >= 3 );
     usage 3;
     :generateDice("randomElement", 1);
   };

--- a/packages/data/src/cards/support/place.gts
+++ b/packages/data/src/cards/support/place.gts
@@ -709,8 +709,7 @@ define card {
     variable point, 1; // 神奇
     on playCard {
       when :(
-        !:isInInitialPile(:e.card) &&
-          :e.card.diceCost() >= :getVariable("point")
+        !:isInInitialPile(:e.card) && :e.playCost() >= :getVariable("point")
       );
       :generateDice("randomElement", 1);
       :addVariable("point", 1);

--- a/packages/test/__tests__/lyresong.test.tsx
+++ b/packages/test/__tests__/lyresong.test.tsx
@@ -13,12 +13,36 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { Character, ref, setup, State, Equipment, Card, $ } from "#test";
+import { Character, ref, setup, State, Equipment, Card, $, Attachment } from "#test";
 import { GildedDreams, TenacityOfTheMillelith } from "@gi-tcg/data/internal/cards/equipment/artifacts.gts";
 import { LeaveItToMe, Lyresong, TheBoarPrincess, TheBoarPrincessInEffect } from "@gi-tcg/data/internal/cards/event/other.gts";
 import { Ganyu } from "@gi-tcg/data/internal/characters/cryo/ganyu.gts";
 import { KamisatoAyaka } from "@gi-tcg/data/internal/characters/cryo/kamisato_ayaka.gts";
 import { expect, test } from "vitest";
+import { CostReduction, NoTuningAllowed } from "@gi-tcg/data/internal/commons.gts";
+
+test("lyresong: returned artifact has no attachments", async () => {
+  const target = ref();
+  const artifact = ref();
+  const c = setup(
+    <State>
+      <Character my ref={target} />
+      <Card my def={TenacityOfTheMillelith} ref={artifact}>
+        <Attachment def={CostReduction} v={{ layer: 2 }} />
+        <Attachment def={NoTuningAllowed} />
+      </Card>
+      <Card my def={Lyresong} />
+    </State>,
+  );
+  c.expect($.my.attachment.on($.id(artifact.id))).toBeCount(2);
+
+  await c.me.card(TenacityOfTheMillelith, target);
+  c.expect($.my.equipment.def(TenacityOfTheMillelith)).toBe(artifact);
+  await c.me.card(Lyresong, target);
+
+  c.expect($.my.hand.def(TenacityOfTheMillelith)).toBe(artifact);
+  c.expect($.my.attachment.on($.id(artifact.id))).toNotExist();
+});
 
 test("lyresong: first play deduct 2 omni", async () => {
   const target = ref();

--- a/packages/test/__tests__/the_power_of_research.test.tsx
+++ b/packages/test/__tests__/the_power_of_research.test.tsx
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 Piovium Labs
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { $, Attachment, Card, Character, ref, setup, State } from "#test";
+import {
+  BrokenRimesEcho,
+  TenacityOfTheMillelith,
+} from "@gi-tcg/data/internal/cards/equipment/artifacts.gts";
+import {
+  StoneAndContracts,
+  ThePowerOfResearch,
+  ThePowerOfResearchInEffect,
+  WaterAndJustice,
+} from "@gi-tcg/data/internal/cards/event/other.gts";
+import { Paimon } from "@gi-tcg/data/internal/cards/support/ally.gts";
+import { FavoniusCathedral } from "@gi-tcg/data/internal/cards/support/place.gts";
+import { CostIncrease, CostReduction } from "@gi-tcg/data/internal/commons.gts";
+import { expect, test } from "vitest";
+
+test.each([
+  { type: "event", threeCost: StoneAndContracts, twoCost: WaterAndJustice },
+  { type: "support", threeCost: Paimon, twoCost: FavoniusCathedral },
+  {
+    type: "equipment",
+    threeCost: TenacityOfTheMillelith,
+    twoCost: BrokenRimesEcho,
+  },
+])(
+  "the power of research uses $type card costs with attachments",
+  async ({ type, threeCost, twoCost }) => {
+    const target = ref();
+    const c = setup(
+      <State>
+        <Character my ref={target} health={8} />
+        <Card my def={ThePowerOfResearch} />
+        <Card my def={threeCost}>
+          <Attachment def={CostReduction} v={{ layer: 1 }} />
+        </Card>
+        <Card my def={twoCost}>
+          <Attachment def={CostIncrease} v={{ layer: 1 }} />
+        </Card>
+      </State>,
+    );
+    const effect = $.my.combatStatus.def(ThePowerOfResearchInEffect);
+    const targets = type === "equipment" ? [target] : [];
+
+    await c.me.card(ThePowerOfResearch);
+    c.expect(effect).toHaveVariable({ usage: 3 });
+    const diceBefore = c.state.players[0].dice.length;
+
+    await c.me.card(threeCost, ...targets);
+    expect
+      .soft(c.expect(effect).states[0])
+      .toMatchObject({ variables: { usage: 3 } });
+    expect.soft(c.state.players[0].dice).toHaveLength(diceBefore - 2);
+
+    const diceBeforeIncreasedCard = c.state.players[0].dice.length;
+    await c.me.card(twoCost, ...targets);
+    expect
+      .soft(c.expect(effect).states[0])
+      .toMatchObject({ variables: { usage: 2 } });
+    expect
+      .soft(c.state.players[0].dice)
+      .toHaveLength(diceBeforeIncreasedCard - 3 + 1);
+  },
+);

--- a/packages/test/__tests__/the_power_of_research.test.tsx
+++ b/packages/test/__tests__/the_power_of_research.test.tsx
@@ -61,18 +61,14 @@ test.each([
     const diceBefore = c.state.players[0].dice.length;
 
     await c.me.card(threeCost, ...targets);
-    expect
-      .soft(c.expect(effect).states[0])
-      .toMatchObject({ variables: { usage: 3 } });
+    c.expect(effect).toHaveVariable({ usage: 3 });
     expect.soft(c.state.players[0].dice).toHaveLength(diceBefore - 2);
 
     const diceBeforeIncreasedCard = c.state.players[0].dice.length;
     await c.me.card(twoCost, ...targets);
-    expect
-      .soft(c.expect(effect).states[0])
-      .toMatchObject({ variables: { usage: 2 } });
-    expect
-      .soft(c.state.players[0].dice)
-      .toHaveLength(diceBeforeIncreasedCard - 3 + 1);
+    c.expect(effect).toHaveVariable({ usage: 2 });
+    expect(c.state.players[0].dice).toHaveLength(
+      diceBeforeIncreasedCard - 3 + 1,
+    );
   },
 );


### PR DESCRIPTION
 `onPlayCard` 事件获取 `e.card.diceCost()` 应当为清理attachment之前的数据。
当前只交了使用 **科研的动力** 的单元测试和回归测试，尚未进行修复。
这可能应该属于核心修复，而不仅限于 **科研的动力** ，因为 **悬木人** 也用到了类似的逻辑。